### PR TITLE
docs: Update Fenrir to Browser Use + Add Eir (OpenEMR)

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -73,7 +73,8 @@ All components of the Asgard AI Platform are covered under the same licensing te
 | 🛡️ **Heimdall** | [megacare-dev/Heimdall](https://github.com/megacare-dev/Heimdall) | LLM Gateway (Rust) |
 | 🧠 **Mimir** | [megacare-dev/Mimir](https://github.com/megacare-dev/Mimir) | RAG + Agent Builder (Rust/Next.js) |
 | ⚡ **Bifrost** | [megacare-dev/Bifrost](https://github.com/megacare-dev/Bifrost) | Agent Runtime (Python) |
-| 🐺 **Fenrir** | [megacare-dev/Fenrir](https://github.com/megacare-dev/Fenrir) | Computer Use (Rust) |
+| 🐺 **Fenrir** | [megacare-dev/Fenrir](https://github.com/megacare-dev/Fenrir) | Computer Use (Python) |
+| 🏥 **Eir** | OpenEMR | Clinic Management (PHP, GPL v3) |
 | 🌳 **Yggdrasil** | [megacare-dev/Yggdrasil](https://github.com/megacare-dev/Yggdrasil) | Auth Service (Zitadel) |
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ docker compose up -d
 | 🛡️ Heimdall | [megacare-dev/Heimdall](https://github.com/megacare-dev/Heimdall) | Rust |
 | 🧠 Mimir | [megacare-dev/Mimir](https://github.com/megacare-dev/Mimir) | Rust + Next.js |
 | ⚡ Bifrost | [megacare-dev/Bifrost](https://github.com/megacare-dev/Bifrost) | Python |
-| 🐺 Fenrir | [megacare-dev/Fenrir](https://github.com/megacare-dev/Fenrir) | Rust |
+| 🐺 Fenrir | [megacare-dev/Fenrir](https://github.com/megacare-dev/Fenrir) | Python |
 
 ## Contributor License Agreement (CLA)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ graph LR
     Bifrost --> |"MCP"| Mimir
     Bifrost --> |"MCP"| Fenrir["🐺 Fenrir<br/>Computer Use"]
 
+    Fenrir --> |"FHIR / Browser"| Eir["🏥 Eir<br/>Clinic (OpenEMR)"]
+
     Heimdall --> LLM["🍎 MLX · llama.cpp · Ollama · vLLM"]
 
     Yggdrasil["🌳 Yggdrasil<br/>Auth (Zitadel)"] -.-> Heimdall
@@ -31,6 +33,7 @@ graph LR
     style Bifrost fill:#451a03,stroke:#f59e0b,color:#fef3c7
     style Heimdall fill:#052e16,stroke:#4ade80,color:#bbf7d0
     style Fenrir fill:#1c1917,stroke:#a8a29e,color:#e7e5e4
+    style Eir fill:#4a1942,stroke:#e879f9,color:#fae8ff
     style Yggdrasil fill:#14532d,stroke:#86efac,color:#bbf7d0
 ```
 
@@ -43,7 +46,8 @@ graph LR
 | 🧠 **[Mimir](https://github.com/megacare-dev/Mimir)** | RAG Pipeline, Agent Builder, Dashboard | Rust (Axum + Rig.rs), Next.js 14, MariaDB, Qdrant | ✅ Sprint 23 |
 | 🛡️ **[Heimdall](https://github.com/megacare-dev/Heimdall)** | LLM Gateway — multi-backend proxy with auth & metrics | Rust (Axum) | ✅ Production |
 | ⚡ **[Bifrost](https://github.com/megacare-dev/Bifrost)** | Agent Runtime Engine — ReAct loop, tool execution, A2A | Python (FastAPI) | 🚧 Scaffolding |
-| 🐺 **[Fenrir](https://github.com/megacare-dev/Fenrir)** | Computer-Use Agent — browser, shell, screen control | Rust (ZeroClaw) | 📋 Planned |
+| 🐺 **[Fenrir](https://github.com/megacare-dev/Fenrir)** | Computer-Use Agent — browser automation, form filling, data extraction | Python (Browser Use + FHIR) | 📋 Planned |
+| 🏥 **Eir** | Clinic Management System — patient records, scheduling, billing | OpenEMR (PHP, GPL v3) | 📋 Planned |
 | 🌳 **Yggdrasil** | Centralized Auth — SSO, RBAC, audit | Zitadel (Go) | 📋 Planned |
 | 🏰 **Asgard** *(this repo)* | Ecosystem docs, architecture, Docker Compose | — | **Public** |
 
@@ -105,7 +109,8 @@ Build a **self-hosted AI platform** that enables:
 - [ ] Unified Docker Compose (all components)
 
 ### Phase 3: Computer Use & Growth
-- [ ] Fenrir — Browser automation, form filling, data extraction
+- [ ] Eir — Deploy OpenEMR, configure FHIR R4 API
+- [ ] Fenrir — Browser automation (Browser Use), Eir integration (FHIR R4 API)
 - [ ] Bifrost — A2A Client for external agents
 - [ ] Agent Template Marketplace
 - [ ] Knowledge Graph (Neo4j — Mimir Sprint 11)
@@ -128,6 +133,7 @@ Build a **self-hosted AI platform** that enables:
 | **Heimdall** | Guardian of Bifrost | LLM Gateway |
 | **Bifrost** | Rainbow bridge | Agent Runtime |
 | **Fenrir** | The great wolf | Computer use |
+| **Eir** | Goddess of healing | Clinic management |
 | **Yggdrasil** | The world tree | Auth service |
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,8 @@ graph LR
 | 🛡️ **Heimdall** | LLM Gateway | Rust (Axum) | ✅ Production |
 | 🧠 **Mimir** | RAG + Agent Builder | Rust (Axum) + Next.js 14 | ✅ Sprint 23 Done |
 | ⚡ **Bifrost** | Agent Runtime | Python (FastAPI) | 🚧 Scaffolding |
-| 🐺 **Fenrir** | Computer Use | Rust (ZeroClaw) | 📋 Planned |
+| 🐺 **Fenrir** | Computer Use | Python (Browser Use + FHIR) | 📋 Planned |
+| 🏥 **Eir** | Clinic Management | OpenEMR (PHP, GPL v3) | 📋 Planned |
 | 🌳 **Yggdrasil** | Auth Service | Zitadel (Go) | 📋 Planned |
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,10 +41,16 @@ graph TB
         end
 
         subgraph fenrir["🐺 Fenrir — Computer Use"]
-            Browser["🌐 Browser Control<br/>Navigate · Extract · Fill"]
+            Browser["🌐 Browser Use<br/>Navigate · Extract · Fill"]
+            FHIRClient["🏥 FHIR Client<br/>API-first"]
             Shell["💻 Shell Executor<br/>Commands · Scripts"]
-            Screen["🖥️ Screen Control<br/>Capture · Click · Type"]
             Files["📁 File Manager<br/>Read · Write · Search"]
+        end
+
+        subgraph eir["🏥 Eir — Clinic Management"]
+            OpenEMR["📋 OpenEMR<br/>Patient · Encounter · Rx"]
+            FHIRAPI["🔗 FHIR R4 API<br/>REST + OAuth2"]
+            OpenEMR --> FHIRAPI
         end
 
         subgraph yggdrasil["🌳 Yggdrasil — Auth"]
@@ -67,6 +73,8 @@ graph TB
     bifrost --> |"LLM calls"| heimdall
     bifrost --> |"RAG search<br/>(MCP)"| mimir
     bifrost --> |"Computer use<br/>(MCP)"| fenrir
+    FHIRClient --> |"FHIR R4"| FHIRAPI
+    Browser --> |"Browser"| OpenEMR
 
     heimdall --> MLX
     heimdall --> Llama
@@ -82,6 +90,7 @@ graph TB
     style bifrost fill:#451a03,stroke:#f59e0b,color:#fef3c7
     style heimdall fill:#052e16,stroke:#4ade80,color:#bbf7d0
     style fenrir fill:#1c1917,stroke:#a8a29e,color:#e7e5e4
+    style eir fill:#4a1942,stroke:#e879f9,color:#fae8ff
     style yggdrasil fill:#14532d,stroke:#86efac,color:#bbf7d0
     style backends fill:#0c0a09,stroke:#78716c
     style client fill:transparent,stroke:#94a3b8
@@ -255,29 +264,31 @@ graph TB
 
 ```mermaid
 graph LR
-    MCP["📡 MCP Server<br/>(Rust)"] --> Browser["🌐 Browser<br/>Playwright"]
+    MCP["📡 MCP Server<br/>(Python)"] --> Browser["🌐 Browser Use<br/>Playwright"]
+    MCP --> FHIR["🏥 FHIR R4<br/>OpenEMR API"]
     MCP --> Shell["💻 Shell<br/>Sandboxed"]
     MCP --> FileOps["📁 Files<br/>Scoped"]
-    MCP --> Screen["🖥️ Screen<br/>macOS APIs"]
 
     Browser --> Web["Navigate · Extract · Fill · Screenshot"]
+    FHIR --> EMR["Patient · Encounter · Observation"]
     Shell --> Cmd["Run commands · Execute scripts"]
     FileOps --> FS["Read · Write · Search"]
-    Screen --> IO["Capture · Click · Type"]
 
     style MCP fill:#1c1917,stroke:#a8a29e
     style Browser fill:#292524,stroke:#78716c
+    style FHIR fill:#292524,stroke:#78716c
     style Shell fill:#292524,stroke:#78716c
     style FileOps fill:#292524,stroke:#78716c
-    style Screen fill:#292524,stroke:#78716c
 ```
 
 | Feature | Description |
 |:--|:--|
-| **Stack** | Rust (ZeroClaw fork) |
+| **Stack** | Python (Browser Use + FHIR Client) |
 | **Port** | `8200` (localhost only) |
 | **Protocol** | MCP Server |
-| **Security** | Sandbox, allowlists, workspace scoping |
+| **Browser** | Browser Use (Playwright-based, natural language) |
+| **API** | FHIR R4 Client for OpenEMR (API-first approach) |
+| **Security** | Sandbox, localhost-only, no external LLM for patient data |
 | **Repo** | [megacare-dev/Fenrir](https://github.com/megacare-dev/Fenrir) |
 
 ---
@@ -301,6 +312,7 @@ graph LR
         P8084["vLLM<br/>:8084"]
         P11434["Ollama<br/>:11434"]
         P8200["Fenrir<br/>:8200"]
+        P80["Eir (OpenEMR)<br/>:80"]
     end
 
     P8080 --> P8081
@@ -325,6 +337,6 @@ graph LR
 | **RAG Backend** | Rust (Axum) + MariaDB + Qdrant | Type-safe, fast, scalable |
 | **Dashboard** | Next.js + React | Modern, SSR, component-based |
 | **Agent Runtime** | Python (FastAPI) | Rich AI ecosystem (MCP, LangGraph) |
-| **Computer Use** | Rust (ZeroClaw) | Lightweight, secure, < 5MB RAM |
+| **Computer Use** | Python (Browser Use + FHIR) | Natural language browser control, OpenEMR integration |
 | **Protocol** | MCP (Model Context Protocol) | Standard tool interface |
 | **Hardware** | Mac Mini M4 Pro, 64GB | Unified memory, 273 GB/s bandwidth |

--- a/docs/strategy/gap-mapping.md
+++ b/docs/strategy/gap-mapping.md
@@ -13,7 +13,7 @@
 | 🧠 **Mimir** | Rust (Axum+Rig.rs), Next.js 14 | ✅ Sprint 1-23 | Multi-Tenant IAM, Dashboard, RAG Pipeline, Data Ingress, Agent Builder, Knowledge Graph, Code Refactoring |
 | 🛡️ **Heimdall** | Rust (Axum) | ✅ Production | Gateway proxy, SSE streaming, Prometheus |
 | ⚡ **Bifrost** | Python (FastAPI) | 🚧 Scaffolding | Project structure, Dockerfile |
-| 🐺 **Fenrir** | Rust (ZeroClaw) | 📋 Planned | README + design |
+| 🐺 **Fenrir** | Python (Browser Use + FHIR) | 📋 Planned | README + design |
 | 🏰 **Asgard** | — | 📄 Docs | README, architecture.md |
 | 🌳 **Yggdrasil** | Zitadel (Go) | 📋 Planned | README + ISO PM-01 |
 

--- a/docs/technical/port-allocation-startup.md
+++ b/docs/technical/port-allocation-startup.md
@@ -31,6 +31,7 @@
 |------|---------|-----------|----------|
 | `8001` | Embedding Server | 🧮 MLX bge-m3 | REST |
 | `8200` | Fenrir (Computer Use) | 🐺 Fenrir | MCP | *reserved* |
+| `80` | Eir (OpenEMR) | 🏥 Eir | HTTP/FHIR | *reserved* |
 
 ### 💾 Infrastructure
 


### PR DESCRIPTION
## Summary

Two documentation updates based on Fenrir browser automation evaluation:

### 1. Fenrir Tech Stack Update (Closes #2)
- **From**: Rust (ZeroClaw)
- **To**: Python (Browser Use + FHIR)
- After evaluating 6 candidates (ZeroClaw, ZeptoClaw, Browser Use, Stagehand, Playwright MCP, Agent Browser), Browser Use was selected for its 89% benchmark score and native form-filling capabilities

### 2. Eir — Clinic Management Component (Closes #3)
- **Codename**: Eir (Norse goddess of healing)
- **Software**: OpenEMR (GPL v3)
- **Port**: `:80` (localhost)
- **Integration**: Fenrir → Eir via FHIR R4 API (primary) + Browser Use (fallback)

### Files Changed (7)
| File | Changes |
|:--|:--|
| `README.md` | Architecture diagram, components, roadmap, Norse naming |
| `docs/architecture.md` | Fenrir/Eir subgraphs, network map, tech stack |
| `docs/README.md` | Component table |
| `COMMERCIAL.md` | Component table |
| `CONTRIBUTING.md` | Language: Rust → Python |
| `docs/strategy/gap-mapping.md` | Tech stack |
| `docs/technical/port-allocation-startup.md` | Eir port :80 |