### PR TITLE
chore(helm): disable laminar subchart in umbrella values

### DIFF
--- a/charts/asgard/values.yaml
+++ b/charts/asgard/values.yaml
@@ -96,9 +96,11 @@ mjolnir:
 
 
 
-# ── Laminar ──
+# ── Laminar (Sága) ──
+# Disabled in umbrella chart — managed by separate `laminar` Helm release.
+# Re-enabling requires migrating ownership of 45 laminar resources first.
 laminar:
-  enabled: true
+  enabled: false
 
 # ── Monitoring ──
 vardr:


### PR DESCRIPTION
## Summary
Set `laminar.enabled: false` in `charts/asgard/values.yaml` so the umbrella chart skips the laminar subchart. The existing standalone `laminar` Helm release continues to manage Sága/Laminar resources independently.

## Why
Deploy workflow [run 25606396143](https://github.com/MegaWiz-Dev-Team/Asgard/actions/runs/25606396143) failed with:
```
Error: UPGRADE FAILED: PersistentVolumeClaim "laminar-clickhouse-data"
in namespace "asgard" exists and cannot be imported into the current
release: invalid ownership metadata; annotation validation error:
key "meta.helm.sh/release-name" must equal "asgard": current value is "laminar"
```

There are **45 laminar resources** owned by the standalone `laminar` release (deployed 2026-04-17). Asgard chart revision 14 has been `failed` since the same date because helm cannot adopt resources owned by another release.

## Risk assessment
- 🟢 **Lowest of 3 paths considered.** Does not touch any laminar resource — laminar release continues working
- Path A (`helm uninstall laminar`): would delete PVCs (reclaim=Delete + no VolumeSnapshotClass) → **data loss**
- Path B (annotation migration): requires re-annotating 45 resources + deleting laminar release secrets, with risk of spec drift causing pod restarts
- Path C (this PR): no resource changes, fully reversible by flipping the flag back

## Verified
- `charts/asgard/Chart.yaml` already declares `laminar` with `condition: laminar.enabled` — disabling the flag cleanly excludes the subchart
- Pre-deploy backup taken: `/Volumes/T7 Shield/asgard-backup-2026-05-10/` (7.6GB — code, configs, k8s manifests, helm release snapshots, all PVC data dumps)

## Future work
To eventually re-adopt laminar into the umbrella chart:
1. Backup all laminar PVC data
2. Annotate 45 resources `meta.helm.sh/release-name=asgard`
3. Delete `sh.helm.release.v1.laminar.v1..v7` secrets
4. Re-enable `laminar.enabled: true`
5. `helm upgrade asgard` — should adopt cleanly

## Test plan
- [ ] Merge → Deploy workflow can be re-triggered
- [ ] Confirm asgard release transitions from `failed` to `deployed`
- [ ] Confirm laminar release stays `deployed` (revision 7) and Sága UI keeps working
- [ ] portal/ehr 503s remain — those need separate fix (image push for asgard-portal/asgard-eir, not in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)