### PR TITLE
fix(helm): match chart to cluster state (Path B drift resolution)

### DIFF
--- a/charts/asgard/charts/mimir/templates/deployment.yaml
+++ b/charts/asgard/charts/mimir/templates/deployment.yaml
@@ -18,14 +18,14 @@ spec:
           ports: [{ containerPort: 8080 }]
           env:
             - { name: PORT, value: "8080" }
-            - { name: DATABASE_URL, value: "mysql://mimir:REDACTED-PW@mariadb.{{ .Release.Namespace }}.svc:3306/mimir" }
-            - { name: QDRANT_URL, value: "http://qdrant.{{ .Release.Namespace }}.svc:6333" }
-            - { name: REDIS_URL, value: "redis://redis.{{ .Release.Namespace }}.svc:6379" }
-            - { name: NEO4J_URI, value: "bolt://neo4j.{{ .Release.Namespace }}.svc:7687" }
+            - { name: DATABASE_URL, value: "mysql://mimir:mimir_password@mariadb.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc:3306/mimir" }
+            - { name: QDRANT_URL, value: "http://qdrant.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc:6333" }
+            - { name: REDIS_URL, value: "redis://redis.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc:6379" }
+            - { name: NEO4J_URI, value: "bolt://neo4j.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc:7687" }
             - { name: NEO4J_USER, value: neo4j }
             - { name: NEO4J_PASSWORD, value: REDACTED-PW }
-            - { name: OLLAMA_API_URL, value: "{{ .Values.global.heimdallUrl }}/v1" }
-            - { name: OLLAMA_URL, value: {{ .Values.global.heimdallUrl | quote }} }
+            - { name: OLLAMA_API_URL, value: "{{ .Values.global.heimdallUrl }}" }
+            - { name: OLLAMA_URL, value: {{ .Values.global.ollamaUrl | default .Values.global.heimdallUrl | quote }} }
             - { name: RUST_LOG, value: {{ .Values.global.rustLog | default "info" | quote }} }
             - { name: YGGDRASIL_ISSUER, value: "http://yggdrasil.{{ .Release.Namespace }}.svc:8080" }
             - { name: YGGDRASIL_CLIENT_ID, value: "368876822349333070" }

--- a/charts/asgard/charts/yggdrasil/templates/deployment.yaml
+++ b/charts/asgard/charts/yggdrasil/templates/deployment.yaml
@@ -15,10 +15,10 @@ spec:
         - name: yggdrasil
           image: {{ .Values.image | default "ghcr.io/zitadel/zitadel:v2.71.6" }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
-          args: ["start-from-init", "--masterkeyFromEnv", "--tlsMode", "disabled"]
+          args: ["start-from-init", "--masterkeyFromEnv", "--tlsMode", "{{ .Values.tlsMode | default `disabled` }}"]
           ports: [{ containerPort: 8080 }]
           env:
-            - { name: ZITADEL_DATABASE_POSTGRES_HOST, value: postgres.{{ .Release.Namespace }}.svc }
+            - { name: ZITADEL_DATABASE_POSTGRES_HOST, value: postgres.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc }
             - { name: ZITADEL_DATABASE_POSTGRES_PORT, value: "5432" }
             - { name: ZITADEL_DATABASE_POSTGRES_DATABASE, value: zitadel }
             - { name: ZITADEL_DATABASE_POSTGRES_USER_USERNAME, value: postgres }
@@ -27,15 +27,15 @@ spec:
             - { name: ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME, value: postgres }
             - { name: ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD, value: yggdrasil-secret }
             - { name: ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE, value: disable }
-            - { name: ZITADEL_EXTERNALSECURE, value: "false" }
-            - { name: ZITADEL_EXTERNALDOMAIN, value: localhost }
-            - { name: ZITADEL_EXTERNALPORT, value: "{{ .Values.nodePort | default 30085 }}" }
+            - { name: ZITADEL_EXTERNALSECURE, value: {{ .Values.externalSecure | default "false" | quote }} }
+            - { name: ZITADEL_EXTERNALDOMAIN, value: {{ .Values.externalDomain | default "localhost" | quote }} }
+            - { name: ZITADEL_EXTERNALPORT, value: {{ .Values.externalPort | default (toString (.Values.nodePort | default 30085)) | quote }} }
             - { name: ZITADEL_FIRSTINSTANCE_ORG_NAME, value: Asgard }
             - { name: ZITADEL_MASTERKEY, value: {{ .Values.masterKey | default "yggdrasil-masterkey-change-me-ok" | quote }} }
             - { name: ZITADEL_DEFAULTINSTANCE_LOGINPOLICY_ALLOWREGISTER, value: "false" }
           readinessProbe:
             httpGet:
-              path: /debug/ready
+              path: {{ .Values.readinessPath | default "/debug/ready" }}
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 30

--- a/charts/asgard/values-dev.yaml
+++ b/charts/asgard/values-dev.yaml
@@ -1,18 +1,29 @@
 # values-dev.yaml — Local development overrides
 global:
   imagePullPolicy: Never
-  heimdallUrl: http://host.docker.internal:8080
+  infraNamespace: asgard-infra
+  heimdallUrl: http://host.docker.internal:8080/v1
+  ollamaUrl: http://192.168.1.172:8080
 
 bifrost:
   defaultModel: mlx-community/Qwen3.5-9B-MLX-4bit
   maxIterations: 10
 
+# Match current PVC capacity in cluster (k8s forbids shrinking bound PVCs)
 infra:
   mariadb:
-    storage: 5Gi
+    storage: 10Gi
   postgres:
-    storage: 2Gi
-  qdrant:
     storage: 5Gi
+  qdrant:
+    storage: 10Gi
   neo4j:
     storage: 2Gi
+
+# Yggdrasil (Zitadel) running in TLS-external mode behind ingress sso.asgard.internal
+yggdrasil:
+  externalSecure: "true"
+  externalDomain: sso.asgard.internal
+  externalPort: "443"
+  tlsMode: external
+  readinessPath: /debug/healthz

--- a/charts/asgard/values.yaml
+++ b/charts/asgard/values.yaml
@@ -3,8 +3,10 @@
 
 global:
   namespace: asgard
+  infraNamespace: asgard-infra  # mariadb/postgres/qdrant/redis/neo4j live here
   imagePullPolicy: Never  # local images; change to IfNotPresent for registry
-  heimdallUrl: http://host.docker.internal:8080
+  heimdallUrl: http://host.docker.internal:8080/v1  # OpenAI-compat path required for bifrost
+  ollamaUrl: http://host.docker.internal:8080  # legacy ollama path (no /v1)
   rustLog: info
   logLevel: info
 
@@ -42,6 +44,11 @@ yggdrasil:
   image: ghcr.io/zitadel/zitadel:v2.71.6
   masterKey: yggdrasil-masterkey-change-me-ok
   nodePort: 30085
+  externalSecure: "false"
+  externalDomain: localhost
+  externalPort: "30085"
+  tlsMode: disabled
+  readinessPath: /debug/ready
 
 # ── Knowledge Platform ──
 mimir:


### PR DESCRIPTION
## Summary
Path B from Helm migration playbook — align chart values + templates with current cluster reality so `helm upgrade` no longer fails on PVC capacity + field-manager conflicts.

After PR #14 (laminar.enabled=false), Deploy run [25607367201](https://github.com/MegaWiz-Dev-Team/Asgard/actions/runs/25607367201) still failed with multiple drift errors. This PR resolves them.

## Drift inventory (all from cluster ↔ chart diff)

| Area | Fields | From | To |
|---|---|---|---|
| PVC sizes | mariadb/postgres/qdrant | 5/2/5Gi | 10/5/10Gi |
| Service namespace | DATABASE_URL, QDRANT_URL, REDIS_URL, NEO4J_URI, ZITADEL_DATABASE_POSTGRES_HOST | `{{ .Release.Namespace }}` | `{{ .Values.global.infraNamespace }}` (default `asgard-infra`) |
| Heimdall path | global.heimdallUrl | `:8080` | `:8080/v1` (OpenAI-compat) |
| Ollama LAN host | new `global.ollamaUrl` (split from heimdallUrl) | — | `192.168.1.172:8080` (separate MLX node) |
| Zitadel mode | externalSecure / Domain / Port / tlsMode / readinessPath | hardcoded localhost+disabled | parameterized; values-dev.yaml sets sso.asgard.internal:443 + external + /debug/healthz |

## Why parameterize instead of hardcode cluster values
- Local dev/CI test environments may still want plain localhost mode
- `values.yaml` keeps safe defaults
- `values-dev.yaml` overrides with the production-shaped sso/TLS config currently running

## Verified locally
```
helm template asgard charts/asgard -f values.yaml -f values-dev.yaml
```
All drifted fields render to exactly match `kubectl get deploy <X> -o yaml` output.

## ⚠️ Known remaining conflict — bifrost image
Cluster pinned to `asgard-bifrost:52659d9-20260418100335` via `kubectl set image`. Chart uses `:latest`. After this PR merges, `helm upgrade` may still report:
```
conflicts with "kubectl-set" using apps/v1:
- .spec.template.spec.containers[name="bifrost"].image
```
Two ways forward (NOT in this PR — separate decision):
- **Reset image to chart default before deploy:**
  `kubectl set image deploy/bifrost bifrost=asgard-bifrost:latest -n asgard`
- **Force conflicts in deploy workflow:** add `--force-conflicts --server-side` to `helm upgrade` (Helm 3.13+)

## Backup safety net
Pre-deploy snapshot at `/Volumes/T7 Shield/asgard-backup-2026-05-10/` (7.6GB — code + configs + k8s manifests + helm release secrets + all PVC data dumps). Rollback via `helm rollback asgard 14` keeps option open.

## Test plan
- [ ] Merge → re-trigger Deploy
- [ ] If bifrost image still conflicts, run `kubectl set image ... :latest` and retry
- [ ] Verify asgard release transitions from `failed` → `deployed`
- [ ] Verify mimir-api / yggdrasil pods restart successfully with new env values

🤖 Generated with [Claude Code](https://claude.com/claude-code)