### PR TITLE
feat(helm): canonical CI-driven image flow via ghcr.io

### DIFF
--- a/charts/asgard/charts/bifrost/templates/deployment.yaml
+++ b/charts/asgard/charts/bifrost/templates/deployment.yaml
@@ -11,10 +11,14 @@ spec:
     metadata:
       labels: { app: bifrost }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: bifrost
-          image: {{ .Values.image | default "asgard-bifrost:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.image | default "ghcr.io/megawiz-dev-team/bifrost:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 8100 }]
           env:
             - { name: BIFROST_HOST, value: "0.0.0.0" }

--- a/charts/asgard/charts/fenrir/templates/deployment.yaml
+++ b/charts/asgard/charts/fenrir/templates/deployment.yaml
@@ -11,10 +11,14 @@ spec:
     metadata:
       labels: { app: fenrir }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: fenrir
-          image: {{ .Values.image | default "asgard-fenrir:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.image | default "ghcr.io/megawiz-dev-team/fenrir:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 8200 }]
           env:
             - { name: FENRIR_HOST, value: "0.0.0.0" }

--- a/charts/asgard/charts/forseti/templates/deployment.yaml
+++ b/charts/asgard/charts/forseti/templates/deployment.yaml
@@ -21,10 +21,14 @@ spec:
     metadata:
       labels: { app: forseti }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: forseti
-          image: {{ .Values.image | default "asgard-forseti:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.image | default "ghcr.io/megawiz-dev-team/forseti:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 5555 }]
           env:
             - { name: FORSETI_HOST, value: "0.0.0.0" }

--- a/charts/asgard/charts/hermodr/templates/deployment.yaml
+++ b/charts/asgard/charts/hermodr/templates/deployment.yaml
@@ -11,10 +11,14 @@ spec:
     metadata:
       labels: { app: hermodr }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: hermodr
-          image: {{ .Values.image | default "asgard-hermodr-yggdrasil:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.image | default "ghcr.io/megawiz-dev-team/hermodr-yggdrasil:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 8090 }]
           env:
             - { name: SERVICE_NAME, value: yggdrasil }
@@ -46,10 +50,14 @@ spec:
     metadata:
       labels: { app: ratatoskr }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: ratatoskr
-          image: {{ .Values.image | default "asgard-ratatoskr:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.image | default "ghcr.io/megawiz-dev-team/ratatoskr:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 9200 }]
           env:
             - { name: PORT, value: "9200" }

--- a/charts/asgard/charts/mimir/templates/deployment.yaml
+++ b/charts/asgard/charts/mimir/templates/deployment.yaml
@@ -11,10 +11,14 @@ spec:
     metadata:
       labels: { app: mimir-api }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: mimir-api
-          image: {{ .Values.api.image | default "asgard-mimir-api:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.api.image | default "ghcr.io/megawiz-dev-team/mimir-api:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 8080 }]
           env:
             - { name: PORT, value: "8080" }
@@ -61,10 +65,14 @@ spec:
     metadata:
       labels: { app: mimir-dashboard }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: mimir-dashboard
-          image: {{ .Values.dashboard.image | default "asgard-mimir-dashboard:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.dashboard.image | default "ghcr.io/megawiz-dev-team/mimir-dashboard:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 3000 }]
           env:
             - { name: NEXT_PUBLIC_API_URL, value: "http://mimir-api.{{ .Release.Namespace }}.svc:8080" }

--- a/charts/asgard/charts/mjolnir/templates/deployment.yaml
+++ b/charts/asgard/charts/mjolnir/templates/deployment.yaml
@@ -21,10 +21,14 @@ spec:
     metadata:
       labels: { app: mjolnir }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: mjolnir
-          image: {{ .Values.image | default "asgard-mjolnir:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.image | default "ghcr.io/megawiz-dev-team/mjolnir:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 8700 }]
           env:
             - { name: MJOLNIR_PORT, value: "8700" }

--- a/charts/asgard/charts/ratatoskr/templates/deployment.yaml
+++ b/charts/asgard/charts/ratatoskr/templates/deployment.yaml
@@ -11,10 +11,14 @@ spec:
     metadata:
       labels: { app: ratatoskr }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: ratatoskr
-          image: {{ .Values.image | default "asgard-ratatoskr:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.image | default "ghcr.io/megawiz-dev-team/ratatoskr:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 9200 }]
           env:
             - { name: PORT, value: "9200" }

--- a/charts/asgard/charts/vardr/templates/deployment.yaml
+++ b/charts/asgard/charts/vardr/templates/deployment.yaml
@@ -11,10 +11,14 @@ spec:
     metadata:
       labels: { app: vardr }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: vardr
-          image: {{ .Values.image | default "asgard-vardr:latest" }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Never" }}
+          image: {{ .Values.image | default "ghcr.io/megawiz-dev-team/vardr:latest" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           ports: [{ containerPort: 9090 }]
           readinessProbe:
             httpGet: { path: /health, port: 9090 }

--- a/charts/asgard/charts/yggdrasil/templates/deployment.yaml
+++ b/charts/asgard/charts/yggdrasil/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
     metadata:
       labels: { app: yggdrasil }
     spec:
+      {{- with .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: yggdrasil
           image: {{ .Values.image | default "ghcr.io/zitadel/zitadel:v2.71.6" }}

--- a/charts/asgard/values-dev.yaml
+++ b/charts/asgard/values-dev.yaml
@@ -1,6 +1,7 @@
 # values-dev.yaml — Local development overrides
 global:
-  imagePullPolicy: Never
+  imagePullPolicy: IfNotPresent  # pull from ghcr.io if not present locally
+  imagePullSecret: ghcr-secret   # private ghcr.io packages — secret pre-created in asgard ns
   infraNamespace: asgard-infra
   heimdallUrl: http://host.docker.internal:8080/v1
   ollamaUrl: http://192.168.1.172:8080

--- a/charts/asgard/values.yaml
+++ b/charts/asgard/values.yaml
@@ -4,7 +4,13 @@
 global:
   namespace: asgard
   infraNamespace: asgard-infra  # mariadb/postgres/qdrant/redis/neo4j live here
-  imagePullPolicy: Never  # local images; change to IfNotPresent for registry
+  # CI-driven image flow: pulls from ghcr.io built by Build-and-Push workflow
+  imageRegistry: ghcr.io/megawiz-dev-team
+  imagePullPolicy: IfNotPresent
+  # Optional: name of pre-existing imagePullSecret if ghcr.io packages are private.
+  # Create with: kubectl create secret docker-registry ghcr-secret \
+  #   --docker-server=ghcr.io --docker-username=<user> --docker-password=<PAT> -n <ns>
+  imagePullSecret: ""
   heimdallUrl: http://host.docker.internal:8080/v1  # OpenAI-compat path required for bifrost
   ollamaUrl: http://host.docker.internal:8080  # legacy ollama path (no /v1)
   rustLog: info
@@ -54,19 +60,19 @@ yggdrasil:
 mimir:
   enabled: true
   api:
-    image: asgard-mimir-api:latest
+    image: ghcr.io/megawiz-dev-team/mimir-api:latest
     nodePort: 30000
     resources:
       requests: { memory: 256Mi, cpu: 200m }
       limits: { memory: 1Gi, cpu: "1" }
   dashboard:
-    image: asgard-mimir-dashboard:latest
+    image: ghcr.io/megawiz-dev-team/mimir-dashboard:latest
     nodePort: 30001
 
 # ── Agent Runtime ──
 bifrost:
   enabled: true
-  image: asgard-bifrost:latest
+  image: ghcr.io/megawiz-dev-team/bifrost:latest
   nodePort: 30100
   defaultModel: mlx-community/Qwen3.5-9B-MLX-4bit
   maxIterations: 10
@@ -75,30 +81,30 @@ bifrost:
 # ── Computer-Use Agent ──
 fenrir:
   enabled: true
-  image: asgard-fenrir:latest
+  image: ghcr.io/megawiz-dev-team/fenrir:latest
   nodePort: 30200
 
 # ── E2E Testing ──
 forseti:
   enabled: true
-  image: asgard-forseti:latest
+  image: ghcr.io/megawiz-dev-team/forseti:latest
   nodePort: 30555
   storage: 1Gi
 
 # ── MCP Sidecar ──
 hermodr:
   enabled: true
-  image: asgard-hermodr-yggdrasil:latest
+  image: ghcr.io/megawiz-dev-team/hermodr-yggdrasil:latest
 
 # ── Browser Service ──
 ratatoskr:
   enabled: true
-  image: asgard-ratatoskr:latest
+  image: ghcr.io/megawiz-dev-team/ratatoskr:latest
 
 # ── Load Testing ──
 mjolnir:
   enabled: true
-  image: asgard-mjolnir:latest
+  image: ghcr.io/megawiz-dev-team/mjolnir:latest
   storage: 1Gi
 
 
@@ -112,5 +118,5 @@ laminar:
 # ── Monitoring ──
 vardr:
   enabled: true
-  image: asgard-vardr:latest
+  image: ghcr.io/megawiz-dev-team/vardr:latest
   nodePort: 30090


### PR DESCRIPTION
## Summary
Switch chart image references from local-build naming (`asgard-X:latest` + `pullPolicy=Never`) to the registry pushed by the Build-and-Push workflow (`ghcr.io/megawiz-dev-team/X:latest` + `pullPolicy=IfNotPresent`).

This is the **canonical Path B fix** for the image-naming gap that surfaced after PR #14 cleared the Helm release-ownership conflict.

## The problem this fixes

After PR #14 (`laminar.enabled=false`) unblocked the Helm release conflict, Deploy [run 25607928028](https://github.com/MegaWiz-Dev-Team/Asgard/actions/runs/25607928028) failed with:
```
resource Deployment/asgard/bifrost not ready. status: InProgress, message: Pending termination
resource Deployment/asgard/ratatoskr not ready. status: Failed, message: Progress deadline exceeded
context deadline exceeded
```

Three layers never matched:
| Layer | Reference |
|---|---|
| Chart expects | `asgard-bifrost:latest` + pullPolicy `Never` |
| Local docker has | `asgard-bifrost:52659d9-20260418100335` (commit tag, no `:latest`) |
| CI pushes | `ghcr.io/megawiz-dev-team/bifrost:latest` (no `asgard-` prefix) |

## Changes

### `values.yaml` — global image flow
- `global.imageRegistry: ghcr.io/megawiz-dev-team` (new, documentary)
- `global.imagePullPolicy`: `Never` → `IfNotPresent`
- `global.imagePullSecret: ""` (new; set if ghcr.io packages are private)
- All per-service `image:` fields rewritten to ghcr.io paths (10 services)

### Subchart templates (10 `deployment.yaml` files)
- Default image strings updated to ghcr.io paths
- Default `imagePullPolicy` switched to `IfNotPresent`
- Conditional `imagePullSecrets` block at pod-spec level — only renders when `global.imagePullSecret` is non-empty

## One-time setup before next Deploy

ghcr.io check showed `WWW-Authenticate: Bearer realm="https://ghcr.io/token"...` → packages are **private**. So:

**Option A (recommended) — make packages public**
GitHub org → Settings → Packages → set each `bifrost`, `mimir-api`, etc. to public. No cluster changes needed.

**Option B — keep private, use imagePullSecret**
```bash
kubectl create secret docker-registry ghcr-secret \\
  --docker-server=ghcr.io \\
  --docker-username=<github-user> \\
  --docker-password=<PAT-with-read:packages> \\
  -n asgard

# Then in values-dev.yaml:
#   global:
#     imagePullSecret: ghcr-secret
```

## Verified locally
```
helm template asgard charts/asgard -f values.yaml
helm template asgard charts/asgard -f values.yaml --set global.imagePullSecret=ghcr-secret
```
First renders no `imagePullSecrets` field; second renders it correctly under each pod spec.

## Out of scope (separate follow-ups)
- 7 services not yet in CI matrix → still 503: `asgard-portal`, `asgard-eir`, `asgard-huginn`, `asgard-llmgoat`, `asgard-muninn`, `asgard-odin`, `syn-api`. Need to extend `.github/workflows/build-and-push.yml` matrix
- Local-dev workflow: `bash scripts/k3s-deploy.sh` still builds `asgard-X:latest` locally. To prefer those, override via `--set global.imagePullPolicy=Never --set bifrost.image=asgard-bifrost:latest` (etc)
- The cluster drift issue (PVC sizes, asgard-infra namespace, yggdrasil TLS-external mode) is separate from image naming and was the focus of PR #15 (which was reverted). Will need a fresh Path B drift PR if Deploy still fails after this lands

## Test plan
- [ ] Decide ghcr.io public vs private + create secret if needed
- [ ] Merge → re-trigger Deploy
- [ ] Verify: `helm list -A | grep asgard` → status `deployed` (not `failed`)
- [ ] Verify: `kubectl describe pod bifrost-... -n asgard` shows successful image pull from ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)