### PR TITLE
ci(build): build multi-arch images (linux/amd64 + linux/arm64)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -61,6 +61,11 @@ jobs:
           path: _service
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -77,6 +82,7 @@ jobs:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest


### PR DESCRIPTION
## Summary
Add multi-arch image builds to the Build-and-Push workflow so images can run on both x86 (Intel/AMD CI runners and servers) and ARM64 (Apple Silicon dev hosts, ARM cloud runners).

## Why
Deploy run [25615306025](https://github.com/MegaWiz-Dev-Team/Asgard/actions/runs/25615306025) — triggered after PR #16 (canonical ghcr.io image flow) — failed because:

```
Failed to pull image "ghcr.io/megawiz-dev-team/fenrir:latest":
no matching manifest for linux/arm64/v8 in the manifest list entries
```

OrbStack k8s on Mac mini Apple Silicon = `linux/arm64/v8`. Previous CI builds were amd64-only.

## Changes
1. Add `docker/setup-qemu-action@v3` step before buildx — installs binfmt handlers for arm64 emulation on the amd64 runner
2. Add `platforms: linux/amd64,linux/arm64` to the build-push-action — produces a multi-arch manifest list

## Trade-off
Multi-arch QEMU build is ~2-3× slower than single-arch native. Acceptable for now. Future optimization: split matrix to use a self-hosted arm64 runner for the arm64 leg (Mac mini already has one), keeping amd64 on ubuntu-latest. Pattern: https://docs.docker.com/build/ci/github-actions/multi-platform/

## Test plan
- [ ] Merge → Build and Push triggers
- [ ] Each `build (X, ...)` job takes ~2-3× longer (8-15 min vs 3-5 min)
- [ ] After build, verify `docker manifest inspect ghcr.io/megawiz-dev-team/bifrost:latest` shows BOTH `linux/amd64` and `linux/arm64`
- [ ] Re-trigger Deploy — pods on OrbStack arm64 should pull successfully

## Other PR queue status
- PR #13 (remove pageindex) — still open, fix CI matrix cleanliness
- This PR (#17 will be) — multi-arch
- After both: clean CI, proper multi-arch images

🤖 Generated with [Claude Code](https://claude.com/claude-code)