### PR TITLE
feat(ci): add asgard-portal to CI build matrix + ghcr.io image

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -33,7 +33,7 @@ jobs:
         name: Detect changed services
         run: |
           if [ "${{ github.event.inputs.service }}" = "all" ] || [ -z "${{ github.event.inputs.service }}" ]; then
-            echo 'services=[{"name":"mimir-api","repo":"Mimir","context":"./_service","dockerfile":"./_service/ro-ai-bridge/Dockerfile"},{"name":"mimir-dashboard","repo":"Mimir","context":"./_service/ro-ai-dashboard","dockerfile":"./_service/ro-ai-dashboard/Dockerfile"},{"name":"bifrost","repo":"Bifrost","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"fenrir","repo":"Fenrir","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"forseti","repo":"Forseti","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"hermodr-yggdrasil","repo":"Hermodr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"ratatoskr","repo":"Ratatoskr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"mjolnir","repo":"Mjolnir","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"vardr","repo":"Vardr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"eir-gateway","repo":"Eir","context":"./_service","dockerfile":"./_service/Dockerfile.gateway"}]' >> $GITHUB_OUTPUT
+            echo 'services=[{"name":"mimir-api","repo":"Mimir","context":"./_service","dockerfile":"./_service/ro-ai-bridge/Dockerfile"},{"name":"mimir-dashboard","repo":"Mimir","context":"./_service/ro-ai-dashboard","dockerfile":"./_service/ro-ai-dashboard/Dockerfile"},{"name":"bifrost","repo":"Bifrost","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"fenrir","repo":"Fenrir","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"forseti","repo":"Forseti","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"hermodr-yggdrasil","repo":"Hermodr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"ratatoskr","repo":"Ratatoskr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"mjolnir","repo":"Mjolnir","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"vardr","repo":"Vardr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"eir-gateway","repo":"Eir","context":"./_service","dockerfile":"./_service/Dockerfile.gateway"},{"name":"asgard-portal","repo":"Asgard","context":"./packages/asgard-portal","dockerfile":"./packages/asgard-portal/Dockerfile"}]' >> $GITHUB_OUTPUT
           else
             # Extremely basic manual trigger filter for simplicity
             echo 'services=[{"name":"mimir-api","repo":"Mimir","context":"./_service","dockerfile":"./_service/ro-ai-bridge/Dockerfile"}]' >> $GITHUB_OUTPUT
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout service repo
+        if: ${{ matrix.service.repo != 'Asgard' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ORG }}/${{ matrix.service.repo }}

--- a/k8s/02-services/asgard-portal/deployment.yaml
+++ b/k8s/02-services/asgard-portal/deployment.yaml
@@ -15,9 +15,11 @@ spec:
       labels:
         app: asgard-portal
     spec:
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: asgard-portal
-          image: asgard-portal:latest
+          image: ghcr.io/megawiz-dev-team/asgard-portal:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 30005


### PR DESCRIPTION
## Summary
Close gap identified in open-core audit: `asgard-portal` source already lives in this public repo (`packages/asgard-portal/`) but is missing from CI → no ghcr.io image → Community users get backend services without admin UI on standard install paths.

## Strategic context
Per [pricing-strategy.md](docs/business/pricing-strategy.md), **Visual Workflow Builder** is a Community feature. asgard-portal hosts that UI. Without a working image distribution, the Community tier promise breaks.

This PR ships the binary distribution. Future PRs will:
- Feature-gate enterprise features (white-label, multi-tenant, advanced RBAC) via runtime license check
- Eventually convert from kubectl-applied service to a proper Helm subchart

## Changes

### `.github/workflows/build-and-push.yml`
1. Add matrix entry:
   ```json
   {"name":"asgard-portal","repo":"Asgard","context":"./packages/asgard-portal","dockerfile":"./packages/asgard-portal/Dockerfile"}
   ```
2. Add `if: matrix.service.repo != 'Asgard'` guard on the second checkout step (avoids redundant Asgard clone)

### `k8s/02-services/asgard-portal/deployment.yaml`
- Image: `asgard-portal:latest` → `ghcr.io/megawiz-dev-team/asgard-portal:latest`
- Added `imagePullSecrets: [ghcr-secret]` for private ghcr.io pull

## Test plan
- [ ] Merge → Build and Push triggers
- [ ] Verify new `build (asgard-portal, Asgard, ./packages/asgard-portal, ...)` job succeeds
- [ ] Verify ghcr.io receives multi-arch image (linux/amd64 + linux/arm64 from PR #17)
- [ ] After Deploy, asgard-portal pod transitions from ImagePullBackOff → Running
- [ ] Verify portal UI reachable at `https://portal.asgard.internal/`

## Related
- Open-core audit gap analysis (Product Owner discussion)
- PR #16 (canonical ghcr.io image flow — this PR follows the same pattern)
- PR #17 (multi-arch CI — asgard-portal will get arm64 manifest automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)