### PR TITLE
ci(perf): split arm64 build to self-hosted Mac mini runner (Path C)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -112,6 +112,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout service repo
+        if: ${{ matrix.service.repo != 'Asgard' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ORG }}/${{ matrix.service.repo }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,4 +1,15 @@
 # 🏰 Asgard — Build & Push Docker Images to ghcr.io
+#
+# Architecture (Path C optimization):
+#   1. detect-changes → emit service matrix
+#   2. build-amd64    → ubuntu-latest (native x86)        — push :sha-amd64 / :latest-amd64
+#   3. build-arm64    → self-hosted Mac mini (native ARM) — push :sha-arm64 / :latest-arm64
+#   4. merge-manifest → ubuntu-latest                     — combine into multi-arch :sha + :latest
+#
+# Why split: each arch builds NATIVE on the right host (no QEMU emulation),
+# 3-5× faster than the prior "QEMU on x86" approach. The merge step creates
+# OCI manifest lists so consumers see one image with both linux/amd64 + linux/arm64.
+
 name: Build and Push
 
 on:
@@ -39,7 +50,7 @@ jobs:
             echo 'services=[{"name":"mimir-api","repo":"Mimir","context":"./_service","dockerfile":"./_service/ro-ai-bridge/Dockerfile"}]' >> $GITHUB_OUTPUT
           fi
 
-  build:
+  build-amd64:
     needs: detect-changes
     runs-on: ubuntu-latest
     strategy:
@@ -62,10 +73,50 @@ jobs:
           path: _service
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU (multi-arch emulation)
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
         with:
-          platforms: arm64
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:${{ github.sha }}-amd64
+            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest-amd64
+          cache-from: type=gha,scope=${{ matrix.service.name }}-amd64
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.name }}-amd64
+
+  build-arm64:
+    needs: detect-changes
+    runs-on: [self-hosted, ARM64]
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+      fail-fast: false
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Asgard
+        uses: actions/checkout@v4
+
+      - name: Checkout service repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ORG }}/${{ matrix.service.repo }}
+          path: _service
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -77,15 +128,51 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push
+      - name: Build and Push (arm64 native)
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: |
-            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:${{ github.sha }}
-            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:${{ github.sha }}-arm64
+            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest-arm64
+          cache-from: type=gha,scope=${{ matrix.service.name }}-arm64
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.name }}-arm64
+
+  merge-manifest:
+    needs: [detect-changes, build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+      fail-fast: false
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest list (sha + latest)
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}"
+          docker buildx imagetools create \
+            -t "$IMAGE:${{ github.sha }}" \
+            -t "$IMAGE:latest" \
+            "$IMAGE:${{ github.sha }}-amd64" \
+            "$IMAGE:${{ github.sha }}-arm64"
+
+      - name: Verify manifest
+        run: |
+          docker buildx imagetools inspect \
+            "${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest"


### PR DESCRIPTION
## Summary
PR #17 enabled multi-arch via QEMU on `ubuntu-latest` — works but is 2-3× slower because the arm64 leg is emulated. Mac mini host already runs an arm64 self-hosted runner, so we can do **native arm64 builds** and parallel-merge the manifest list.

This is the **Path C optimization** discussed in the open-core blog post.

## Architecture

**Before** (PR #17): single `build` job, ubuntu-latest with QEMU, producing multi-arch image in one shot.

**After** (this PR):
| Job | Runner | Role |
|---|---|---|
| `build-amd64`     | `ubuntu-latest`         | Native x86 build, push `:sha-amd64` + `:latest-amd64` |
| `build-arm64`     | `[self-hosted, ARM64]`  | Native ARM build on Mac mini, push `:sha-arm64` + `:latest-arm64` |
| `merge-manifest`  | `ubuntu-latest`         | `docker buildx imagetools create` combines per-arch tags into multi-arch manifest list `:sha` + `:latest` |

Per-arch images are intermediate artifacts; consumers see one image with both arches via the merged manifest.

## Expected wins

| Stage | PR #17 (QEMU) | This PR (native) |
|---|---|---|
| amd64 build/svc | ~5 min | ~5 min |
| arm64 build/svc | ~10-15 min | ~3-5 min |
| manifest merge | n/a (single job) | ~30s |
| **Total wall (per service)** | ~25-40 min | ~8-15 min |

3-5× speedup, especially noticeable on Rust workspace (`mimir-api`) and Next.js (`mimir-dashboard`) which were the slowest in QEMU. Recent Build run [25615546331](https://github.com/MegaWiz-Dev-Team/Asgard/actions/runs/25615546331) had `mimir-api`/`mimir-dashboard` running for 60+ min — this PR addresses that directly.

## Trade-offs

- **Self-hosted runner dependency**: Mac mini runner (`actions.runner.MegaWiz-Dev-Team-Asgard.MacMini-Runner`, bootstrapped this session) must be online. If offline, arm64 leg fails → no manifest merge → no published `:latest`.
- **Future hardening** (separate PR): add `if:` fallback to QEMU on ubuntu-latest when self-hosted is unavailable.
- **GHA cache per-arch**: `scope=<svc>-amd64` / `<svc>-arm64`. Slightly larger total footprint but each scope is clean.

## Test plan
- [ ] Merge → trigger Build and Push
- [ ] Verify all 3 jobs (build-amd64, build-arm64, merge-manifest) run
- [ ] Check `docker manifest inspect ghcr.io/megawiz-dev-team/bifrost:latest` shows BOTH `linux/amd64` and `linux/arm64`
- [ ] Compare total wall clock vs prior multi-arch QEMU run

## Coordinates with
- PR #18 (asgard-portal CI) — both modify `build-and-push.yml`. Recommend merging PR #18 first (smaller scope), then rebasing this one
- PR #13 (remove pageindex) — still open; can merge in any order

🤖 Generated with [Claude Code](https://claude.com/claude-code)