### PR TITLE
hotfix(ci): use /tmp instead of runner.temp (not in job env scope)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -109,9 +109,10 @@ jobs:
     # Bypass macOS Keychain (-25308 "User interaction is not allowed") on the
     # self-hosted Mac mini runner — docker login defaults to osxkeychain
     # credstore, which is locked when no GUI session is unlocked.
-    # Pointing DOCKER_CONFIG at a fresh tmp dir forces file-based config.json.
+    # Pointing DOCKER_CONFIG at /tmp forces file-based config.json.
+    # Note: `runner.temp` is not available in job-level env, so use literal /tmp.
     env:
-      DOCKER_CONFIG: ${{ runner.temp }}/.docker-${{ github.run_id }}-${{ matrix.service.name }}
+      DOCKER_CONFIG: /tmp/.docker-${{ github.run_id }}-${{ matrix.service.name }}
 
     steps:
       - name: Checkout Asgard


### PR DESCRIPTION
## Summary
PR #20's DOCKER_CONFIG fix used \`\${{ runner.temp }}\` at job level, but that context is only available in step expressions — workflow now fails to parse:

\`\`\`
Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.temp
\`\`\`

Resolves immediately with literal \`/tmp\` (writable on Mac mini self-hosted runner).

## Diff
\`\`\`diff
- DOCKER_CONFIG: \${{ runner.temp }}/.docker-...
+ DOCKER_CONFIG: /tmp/.docker-\${{ github.run_id }}-\${{ matrix.service.name }}
\`\`\`