### PR TITLE
revert(ci): drop split-arch (PR #19) → restore QEMU multi-arch (PR #17)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,14 +1,12 @@
 # 🏰 Asgard — Build & Push Docker Images to ghcr.io
 #
-# Architecture (Path C optimization):
-#   1. detect-changes → emit service matrix
-#   2. build-amd64    → ubuntu-latest (native x86)        — push :sha-amd64 / :latest-amd64
-#   3. build-arm64    → self-hosted Mac mini (native ARM) — push :sha-arm64 / :latest-arm64
-#   4. merge-manifest → ubuntu-latest                     — combine into multi-arch :sha + :latest
+# Multi-arch via QEMU on ubuntu-latest. Slower than native (8-15 min/svc
+# instead of 3-5 min) but works without depending on a self-hosted runner.
 #
-# Why split: each arch builds NATIVE on the right host (no QEMU emulation),
-# 3-5× faster than the prior "QEMU on x86" approach. The merge step creates
-# OCI manifest lists so consumers see one image with both linux/amd64 + linux/arm64.
+# History: PR #19 split arm64 to a self-hosted Mac mini runner for native
+# speed, but the Mac mini's launchd-managed runner can't access osxkeychain
+# (-25308 errors during docker login). Reverted to QEMU until the runner
+# is reconfigured with file-based docker credstore (or non-keychain login).
 
 name: Build and Push
 
@@ -50,7 +48,7 @@ jobs:
             echo 'services=[{"name":"mimir-api","repo":"Mimir","context":"./_service","dockerfile":"./_service/ro-ai-bridge/Dockerfile"}]' >> $GITHUB_OUTPUT
           fi
 
-  build-amd64:
+  build:
     needs: detect-changes
     runs-on: ubuntu-latest
     strategy:
@@ -73,6 +71,11 @@ jobs:
           path: _service
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -83,111 +86,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push (amd64)
+      - name: Build and Push (multi-arch)
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:${{ github.sha }}-amd64
-            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest-amd64
-          cache-from: type=gha,scope=${{ matrix.service.name }}-amd64
-          cache-to: type=gha,mode=max,scope=${{ matrix.service.name }}-amd64
-
-  build-arm64:
-    needs: detect-changes
-    runs-on: [self-hosted, ARM64]
-    strategy:
-      matrix:
-        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
-      fail-fast: false
-    permissions:
-      contents: read
-      packages: write
-    # Bypass macOS Keychain (-25308 "User interaction is not allowed") on the
-    # self-hosted Mac mini runner — docker login defaults to osxkeychain
-    # credstore, which is locked when no GUI session is unlocked.
-    # Pointing DOCKER_CONFIG at /tmp forces file-based config.json.
-    # Note: `runner.temp` is not available in job-level env, so use literal /tmp.
-    env:
-      DOCKER_CONFIG: /tmp/.docker-${{ github.run_id }}-${{ matrix.service.name }}
-
-    steps:
-      - name: Checkout Asgard
-        uses: actions/checkout@v4
-
-      - name: Checkout service repo
-        if: ${{ matrix.service.repo != 'Asgard' }}
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.ORG }}/${{ matrix.service.repo }}
-          path: _service
-          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
-
-      - name: Prepare DOCKER_CONFIG (override osxkeychain credstore)
-        run: |
-          mkdir -p "$DOCKER_CONFIG"
-          # Empty config.json with NO credsStore — forces docker login to
-          # write auth blob to file instead of macOS Keychain (-25308 fix)
-          echo '{}' > "$DOCKER_CONFIG/config.json"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and Push (arm64 native)
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.service.context }}
-          file: ${{ matrix.service.dockerfile }}
-          push: true
-          platforms: linux/arm64
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:${{ github.sha }}-arm64
-            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest-arm64
-          cache-from: type=gha,scope=${{ matrix.service.name }}-arm64
-          cache-to: type=gha,mode=max,scope=${{ matrix.service.name }}-arm64
-
-  merge-manifest:
-    needs: [detect-changes, build-amd64, build-arm64]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
-      fail-fast: false
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create multi-arch manifest list (sha + latest)
-        run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}"
-          docker buildx imagetools create \
-            -t "$IMAGE:${{ github.sha }}" \
-            -t "$IMAGE:latest" \
-            "$IMAGE:${{ github.sha }}-amd64" \
-            "$IMAGE:${{ github.sha }}-arm64"
-
-      - name: Verify manifest
-        run: |
-          docker buildx imagetools inspect \
-            "${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest"
+            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service.name }}:latest
+          cache-from: type=gha,scope=${{ matrix.service.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.name }}


### PR DESCRIPTION
## Summary
PR #19's split-arch optimization can't work without runner-side reconfig: Mac mini self-hosted runner runs as launchd daemon → no UI session → osxkeychain locked → \`docker login\` fails (-25308) on every arm64 build.

Workarounds attempted, both insufficient:
- PR #20: \`DOCKER_CONFIG\` → /tmp (didn't bypass keychain credstore)
- PR #22: pre-write empty \`{}\` config.json (also didn't bypass — docker on macOS hardcodes credstore default at system level)

For now revert to QEMU multi-arch on \`ubuntu-latest\` (PR #17 architecture). 8-15 min/svc instead of 3-5 min native, but **works reliably**.

## What's preserved
- asgard-portal in matrix (PR #18) ✓
- pageindex removed (PR #13) ✓
- Cargo.lock tracked for asgard-portal (PR #20) ✓
- \`if: matrix.service.repo != 'Asgard'\` checkout guard ✓
- GHA cache scoped per service ✓

## Future work (separate issue)
- Reconfigure self-hosted runner: clear \`credsStore\` from Docker Desktop settings or \`~/.docker/config.json\`
- Or use a different login approach that doesn't trigger credstore (raw \`docker login --password-stdin\` with empty config)
- Or run runner under a logged-in user account (keychain unlocked)

Then re-introduce split-arch as a follow-up PR.

## Test plan
- [ ] Merge → trigger Build
- [ ] All 11 services build multi-arch via QEMU on ubuntu-latest
- [ ] No -25308 errors (no self-hosted runner involved)
- [ ] Trigger Deploy → asgard-portal pod transitions ImagePullBackOff → Running