### PR TITLE
fix(ci): special-case bifrost — checkout Bifrost+Mimir sibling layout

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,7 +42,7 @@ jobs:
         name: Detect changed services
         run: |
           if [ "${{ github.event.inputs.service }}" = "all" ] || [ -z "${{ github.event.inputs.service }}" ]; then
-            echo 'services=[{"name":"mimir-api","repo":"Mimir","context":"./_service","dockerfile":"./_service/ro-ai-bridge/Dockerfile"},{"name":"mimir-dashboard","repo":"Mimir","context":"./_service/ro-ai-dashboard","dockerfile":"./_service/ro-ai-dashboard/Dockerfile"},{"name":"bifrost","repo":"Bifrost","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"fenrir","repo":"Fenrir","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"forseti","repo":"Forseti","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"hermodr-yggdrasil","repo":"Hermodr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"ratatoskr","repo":"Ratatoskr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"mjolnir","repo":"Mjolnir","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"vardr","repo":"Vardr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"eir-gateway","repo":"Eir","context":"./_service","dockerfile":"./_service/Dockerfile.gateway"},{"name":"asgard-portal","repo":"Asgard","context":"./packages/asgard-portal","dockerfile":"./packages/asgard-portal/Dockerfile"}]' >> $GITHUB_OUTPUT
+            echo 'services=[{"name":"mimir-api","repo":"Mimir","context":"./_service","dockerfile":"./_service/ro-ai-bridge/Dockerfile"},{"name":"mimir-dashboard","repo":"Mimir","context":"./_service/ro-ai-dashboard","dockerfile":"./_service/ro-ai-dashboard/Dockerfile"},{"name":"bifrost","repo":"Bifrost","context":".","dockerfile":"./Bifrost/Dockerfile"},{"name":"fenrir","repo":"Fenrir","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"forseti","repo":"Forseti","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"hermodr-yggdrasil","repo":"Hermodr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"ratatoskr","repo":"Ratatoskr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"mjolnir","repo":"Mjolnir","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"vardr","repo":"Vardr","context":"./_service","dockerfile":"./_service/Dockerfile"},{"name":"eir-gateway","repo":"Eir","context":"./_service","dockerfile":"./_service/Dockerfile.gateway"},{"name":"asgard-portal","repo":"Asgard","context":"./packages/asgard-portal","dockerfile":"./packages/asgard-portal/Dockerfile"}]' >> $GITHUB_OUTPUT
           else
             # Extremely basic manual trigger filter for simplicity
             echo 'services=[{"name":"mimir-api","repo":"Mimir","context":"./_service","dockerfile":"./_service/ro-ai-bridge/Dockerfile"}]' >> $GITHUB_OUTPUT
@@ -64,11 +64,30 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout service repo
-        if: ${{ matrix.service.repo != 'Asgard' }}
+        if: ${{ matrix.service.repo != 'Asgard' && matrix.service.name != 'bifrost' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ORG }}/${{ matrix.service.repo }}
           path: _service
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      # Bifrost has a relative-path Cargo workspace dep on Mimir/ro-ai-bridge —
+      # see Bifrost issue #11. Until refactored, mirror the local sibling
+      # layout in CI: Bifrost/ + Mimir/ at the workspace root.
+      - name: Checkout Bifrost (sibling layout)
+        if: ${{ matrix.service.name == 'bifrost' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ORG }}/Bifrost
+          path: Bifrost
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout Mimir for Bifrost build (sibling layout)
+        if: ${{ matrix.service.name == 'bifrost' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ORG }}/Mimir
+          path: Mimir
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU (arm64 emulation)


### PR DESCRIPTION
Workaround for [Bifrost#11](https://github.com/MegaWiz-Dev-Team/Bifrost/issues/11) — Bifrost has Cargo path dep on Mimir/ro-ai-bridge, requires sibling-dir build context. Special-case in Asgard CI: skip generic _service checkout for bifrost; clone Bifrost+Mimir each into its own dir at workspace root; build with context=. Removes the persistent bifrost CI failure. To revert when Bifrost#11 is properly fixed, restore generic matrix entry + remove conditional checkouts.