### PR TITLE
chore(governance): CODEOWNERS + branching strategy in CONTRIBUTING

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,46 @@
+# Asgard CODEOWNERS — auto-request review for PRs touching specific paths
+# Lines later in the file override earlier rules.
+# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Format: <path-glob>  <@github-username | @org/team>
+#
+# Catch-all — everyone needs at least one approval from a maintainer.
+
+* @megacare-dev
+
+# ── CI/CD pipeline ─────────────────────────────────────────────
+# Workflow changes affect every Build and Deploy. Review carefully.
+/.github/workflows/                    @megacare-dev
+/.github/CODEOWNERS                    @megacare-dev
+/scripts/k3s-deploy.sh                 @megacare-dev
+
+# ── Helm charts ────────────────────────────────────────────────
+# Chart changes are deployed to all clusters. Require maintainer review.
+/charts/                               @megacare-dev
+/charts/asgard/values.yaml             @megacare-dev
+/charts/asgard/values-dev.yaml         @megacare-dev
+/charts/asgard/values-prod.yaml        @megacare-dev
+
+# ── K8s manifests (kubectl-applied, not Helm) ──────────────────
+/k8s/                                  @megacare-dev
+
+# ── Business / strategy docs ──────────────────────────────────
+# Sensitive: pricing, business plan, go-to-market. Require explicit owner sign-off.
+/docs/business/                        @megacare-dev
+/docs/strategy/                        @megacare-dev
+
+# ── Architecture decisions ────────────────────────────────────
+/docs/architecture/                    @megacare-dev
+
+# ── In-repo packages ──────────────────────────────────────────
+/packages/asgard-portal/               @megacare-dev
+/packages/email_service/               @megacare-dev
+/packages/line_connector/              @megacare-dev
+/packages/tts_service/                 @megacare-dev
+
+# ── Security policy ───────────────────────────────────────────
+/SECURITY.md                           @megacare-dev
+/CODE_OF_CONDUCT.md                    @megacare-dev
+/CONTRIBUTING.md                       @megacare-dev
+/LICENSE                               @megacare-dev
+/LICENSE-COMMERCIAL.md                 @megacare-dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,84 @@ Please [open an issue](https://github.com/MegaWiz-Dev-Team/Asgard/issues/new) wi
 ### 🔧 Pull Requests
 
 1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/my-feature`
+2. Create a branch with the right prefix (see [Branching Strategy](#branching-strategy) below)
 3. Make your changes
 4. Write/update tests if applicable
 5. Commit with [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, etc.
 6. Push to your fork and open a PR
+7. Wait for CI (Build and Push) to pass + 1 maintainer approval (see [CODEOWNERS](.github/CODEOWNERS))
+
+## Branching Strategy
+
+Asgard uses **GitHub Flow + Release Trunk** (hybrid).
+
+### Day-to-day development
+
+```
+main            ← always-deployable, latest stable
+  ↑
+  PR with required CI passing + 1 approval
+  ↑
+feat/<short>    ← new feature
+fix/<short>     ← bug fix
+chore/<short>   ← tooling/refactor (no behavior change)
+docs/<short>    ← docs-only
+revert/<orig>   ← explicit revert
+```
+
+| Prefix | Use for | Example |
+|---|---|---|
+| `feat/` | New feature, user-visible behavior | `feat/multi-tenant-rbac` |
+| `fix/` | Bug fix, no API change | `fix/oidc-issuer-internal-url` |
+| `chore/` | Tooling, deps, refactor | `chore/upgrade-rust-1.88` |
+| `docs/` | Docs-only changes | `docs/sprint-51d-retro` |
+| `hotfix/` | Urgent fix to a release branch | `hotfix/v1.0.x-cve-2026-12345` |
+| `release/` | LTS release branch (maintainer-only) | `release/v1.0` |
+| `revert/` | Explicit revert of a prior change | `revert/pr-19-split-arch` |
+
+### Release branches (LTS)
+
+Once Asgard hits Enterprise GA (Q3 2027), each minor version gets a long-lived `release/v<major>.<minor>` branch:
+
+```
+release/v1.0    ← LTS, 12-month support window
+release/v1.1    ← current, will become LTS when v1.2 ships
+main            ← v1.2-dev (next release)
+```
+
+**Backport policy:**
+- Bug fix lands on `main` first → cherry-pick to `release/v1.0`, `release/v1.1` if applicable
+- Security fixes (CVE) → backport to all supported release branches
+- Features stay on `main` only — never backport to LTS
+
+### Image / version tagging
+
+| Source | Image tag pushed to ghcr.io |
+|---|---|
+| `main` push | `:sha-<commit>` + `:edge` |
+| Tag `v1.1.0` | `:v1.1.0` (immutable) + `:1.1` (rolling within minor) |
+| `:latest` | latest stable release (default for community) |
+
+Enterprise customers should pin to specific `:v1.X` (LTS) per their support contract.
+
+### Branch protection rules (enforced)
+
+`main` and `release/*` branches require:
+- ✅ Pull Request with at least **1 maintainer approval** (per [CODEOWNERS](.github/CODEOWNERS))
+- ✅ Status check: **Build and Push** workflow must pass
+- ✅ Branch must be up-to-date with target before merging
+- ✅ **Linear history** — squash or rebase merge only (no merge commits)
+- ❌ No force-push, no branch deletion
+- ❌ No bypass except for documented emergencies (audit-logged)
+
+### Hotfix flow (security/critical)
+
+1. Branch from `release/v1.0` → `hotfix/v1.0.x-<short>`
+2. Fix + add regression test
+3. Open PR to `release/v1.0` (require security review for CVEs)
+4. Tag `v1.0.x` once merged → CI builds + ships hotfix image
+5. Cherry-pick to `main` and other supported release branches
+6. Publish [GitHub Security Advisory](https://github.com/MegaWiz-Dev-Team/Asgard/security/advisories) for CVEs
 
 ### 📝 Documentation
 


### PR DESCRIPTION
## Summary
Sprint 51d quick-win — set governance rules before community/customer launch.

Per business plan timeline (Community Launch Q4 2026, Enterprise Pilot Q1 2027, Enterprise GA Q3 2027), basic governance should be in place now while there's no external traffic — easier to enforce policy on yourself before contributors/customers depend on it.

## Files
- **`.github/CODEOWNERS`** (new) — auto-request review per area
- **`CONTRIBUTING.md`** — added "Branching Strategy" section with branch prefixes, release branch model, image tagging policy, branch protection rules, hotfix flow

## Design
**Hybrid: GitHub Flow + Release Trunk**
- `main` for active development (always-deployable)
- `release/v<major>.<minor>` long-lived LTS branches once Enterprise GA hits
- 7 branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `hotfix/`, `release/`, `revert/`

## Manual follow-up (not in this PR)
After merge, enable branch protection at: https://github.com/MegaWiz-Dev-Team/Asgard/settings/branches
- Branch pattern: `main`
- ✅ Require PR + 1 approval
- ✅ Require status check: "Build and Push"
- ✅ Require linear history (squash/rebase only)
- ❌ No force-push, no delete

Same rules later for `release/*` once first LTS branch is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)