### PR TITLE
feat(helm): parameterize YGGDRASIL_ISSUER

### DIFF
--- a/charts/asgard/charts/mimir/templates/deployment.yaml
+++ b/charts/asgard/charts/mimir/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - { name: OLLAMA_API_URL, value: "{{ .Values.global.heimdallUrl }}" }
             - { name: OLLAMA_URL, value: {{ .Values.global.ollamaUrl | default .Values.global.heimdallUrl | quote }} }
             - { name: RUST_LOG, value: {{ .Values.global.rustLog | default "info" | quote }} }
-            - { name: YGGDRASIL_ISSUER, value: "http://yggdrasil.{{ .Release.Namespace }}.svc:8080" }
+            - { name: YGGDRASIL_ISSUER, value: {{ .Values.global.yggdrasilIssuerUrl | default (printf "http://yggdrasil.%s.svc:8080" .Release.Namespace) | quote }} }
             - { name: YGGDRASIL_CLIENT_ID, value: "368876822349333070" }
             - { name: YGGDRASIL_CLIENT_SECRET, value: "jlQ7malc0cl4Ky0XlvgDqhDxXsK6Ogtv3SfSAoexyU12sMxqrIkMFPI6GOgA0Xy6" }
           readinessProbe:
@@ -77,8 +77,8 @@ spec:
           env:
             - { name: NEXT_PUBLIC_API_URL, value: "http://mimir-api.{{ .Release.Namespace }}.svc:8080" }
             - { name: MIMIR_API_URL, value: "http://mimir-api.{{ .Release.Namespace }}.svc:8080/api" }
-            - { name: NEXT_PUBLIC_YGGDRASIL_URL, value: "http://yggdrasil.{{ .Release.Namespace }}.svc:8080" }
-            - { name: YGGDRASIL_ISSUER, value: "http://yggdrasil.{{ .Release.Namespace }}.svc:8080" }
+            - { name: NEXT_PUBLIC_YGGDRASIL_URL, value: {{ .Values.global.yggdrasilIssuerUrl | default (printf "http://yggdrasil.%s.svc:8080" .Release.Namespace) | quote }} }
+            - { name: YGGDRASIL_ISSUER, value: {{ .Values.global.yggdrasilIssuerUrl | default (printf "http://yggdrasil.%s.svc:8080" .Release.Namespace) | quote }} }
             - { name: YGGDRASIL_CLIENT_ID, value: "368876822349333070" }
             - { name: YGGDRASIL_CLIENT_SECRET, value: "jlQ7malc0cl4Ky0XlvgDqhDxXsK6Ogtv3SfSAoexyU12sMxqrIkMFPI6GOgA0Xy6" }
           resources:

--- a/charts/asgard/values.yaml
+++ b/charts/asgard/values.yaml
@@ -13,6 +13,10 @@ global:
   imagePullSecret: ""
   heimdallUrl: http://host.docker.internal:8080/v1  # OpenAI-compat path required for bifrost
   ollamaUrl: http://host.docker.internal:8080  # legacy ollama path (no /v1)
+  # OIDC issuer URL — must be browser-reachable since Yggdrasil/Zitadel
+  # bakes it into redirects (see Sprint 51d hotfix). Override per env in
+  # values-dev.yaml / values-prod.yaml.
+  yggdrasilIssuerUrl: https://sso.asgard.internal
   rustLog: info
   logLevel: info
 


### PR DESCRIPTION
## Summary

Sprint 51d hotfix patched `mimir-api` YGGDRASIL_ISSUER via \`kubectl set env\`, but every Helm upgrade reverts it because the chart hard-coded the internal SVC URL (\`http://yggdrasil.<ns>.svc:8080\`).

This PR drives YGGDRASIL_ISSUER from \`global.yggdrasilIssuerUrl\` (default: \`https://sso.asgard.internal\` — must be browser-reachable since Zitadel bakes the issuer into OIDC redirects).

## Test plan

- [ ] \`helm upgrade asgard ./charts/asgard -n asgard\` — verify mimir-api/mimir-dashboard envs
- [ ] Mimir login flow works end-to-end without manual \`kubectl set env\` patch
- [ ] Override in values-dev.yaml / values-prod.yaml works

Closes Sprint 51d Path A item B-51d.1 → carried as Sprint 51e B-51e.1.

## ⚠️ Out-of-scope but flagged

While editing this file, noticed \`YGGDRASIL_CLIENT_SECRET\` (and several other passwords) are committed plaintext in chart templates. Repo is public. **Tracked separately as security hardening item — not addressed in this PR.**