### PR TITLE
fix(security): migrate plaintext secrets to K8s Secret

### DIFF
--- a/charts/asgard/charts/bifrost/templates/deployment.yaml
+++ b/charts/asgard/charts/bifrost/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
             - { name: BIFROST_HOST, value: "0.0.0.0" }
             - { name: BIFROST_PORT, value: "8100" }
             - { name: HEIMDALL_URL, value: {{ .Values.global.heimdallUrl | quote }} }
+            - name: HEIMDALL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.secretsName | default "asgard-secrets" }}
+                  key: HEIMDALL_API_KEY
             - { name: MIMIR_URL, value: "http://mimir-api.{{ .Release.Namespace }}.svc:8080" }
             - { name: YGGDRASIL_MCP_URL, value: "http://hermodr.{{ .Release.Namespace }}.svc:8090/rpc" }
             - { name: YGGDRASIL_MCP_ENABLED, value: "true" }

--- a/charts/asgard/charts/infra/templates/all.yaml
+++ b/charts/asgard/charts/infra/templates/all.yaml
@@ -29,10 +29,12 @@ spec:
           image: mariadb:11
           ports: [{ containerPort: 3306 }]
           env:
-            - { name: MYSQL_ROOT_PASSWORD, value: {{ .Values.mariadb.rootPassword | quote }} }
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: MARIADB_ROOT_PASSWORD } }
             - { name: MYSQL_DATABASE, value: {{ .Values.mariadb.database | quote }} }
             - { name: MYSQL_USER, value: {{ .Values.mariadb.user | quote }} }
-            - { name: MYSQL_PASSWORD, value: {{ .Values.mariadb.password | quote }} }
+            - name: MYSQL_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: MARIADB_PASSWORD } }
           volumeMounts:
             - { name: data, mountPath: /var/lib/mysql }
           readinessProbe:
@@ -87,7 +89,8 @@ spec:
           ports: [{ containerPort: 5432 }]
           env:
             - { name: POSTGRES_USER, value: {{ .Values.postgres.user | quote }} }
-            - { name: POSTGRES_PASSWORD, value: {{ .Values.postgres.password | quote }} }
+            - name: POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: YGGDRASIL_POSTGRES_PASSWORD } }
             - { name: POSTGRES_DB, value: {{ .Values.postgres.database | quote }} }
           volumeMounts:
             - { name: data, mountPath: /var/lib/postgresql/data }

--- a/charts/asgard/charts/infra/templates/otel-collector.yaml
+++ b/charts/asgard/charts/infra/templates/otel-collector.yaml
@@ -15,6 +15,13 @@ data:
 
     exporters:
       # Export to Laminar Backend
+      # NOTE: laminar API key was previously plaintext-rendered here from
+      # .Values.infra.laminarApiKey. Removed in Sprint 51e security refactor.
+      # Since laminar is disabled in the umbrella chart by default, this
+      # exporter ships with a placeholder Bearer token; traces drop until
+      # operator sets .Values.infra.laminarApiKey explicitly OR re-wires
+      # this to read from the asgard-secrets Secret via envFrom on the
+      # collector pod (TODO: Sprint 51e+1).
       otlp/laminar:
         endpoint: "laminar-app-server.{{ .Release.Namespace }}.svc:8001"
         tls:

--- a/charts/asgard/charts/laminar/templates/clickhouse.yaml
+++ b/charts/asgard/charts/laminar/templates/clickhouse.yaml
@@ -29,7 +29,8 @@ spec:
             - containerPort: 9000
           env:
             - { name: CLICKHOUSE_USER, value: "default" }
-            - { name: CLICKHOUSE_PASSWORD, value: "laminar_ck_secret" }
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_CLICKHOUSE_PASSWORD } }
           resources:
             requests: { memory: "512Mi" }
             limits: { memory: "2Gi" }

--- a/charts/asgard/charts/laminar/templates/laminar-core.yaml
+++ b/charts/asgard/charts/laminar/templates/laminar-core.yaml
@@ -110,13 +110,16 @@ spec:
           env:
             - { name: PORT, value: "8000" }
             - { name: GRPC_PORT, value: "8001" }
-            - { name: DATABASE_URL, value: "postgres://postgres:{{ .Values.postgres.password }}@laminar-postgres:5432/laminar" }
+            - name: DATABASE_URL
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_POSTGRES_URL } }
             - { name: SHARED_SECRET_TOKEN, value: {{ .Values.global.sharedSecretToken | quote }} }
             - { name: CLICKHOUSE_URL, value: "http://laminar-clickhouse:8123" }
             - { name: CLICKHOUSE_USER, value: "default" }
-            - { name: CLICKHOUSE_PASSWORD, value: "laminar_ck_secret" }
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_CLICKHOUSE_PASSWORD } }
             - { name: CLICKHOUSE_RO_USER, value: "default" }
-            - { name: CLICKHOUSE_RO_PASSWORD, value: "laminar_ck_secret" }
+            - name: CLICKHOUSE_RO_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_CLICKHOUSE_RO_PASSWORD } }
             - { name: ENVIRONMENT, value: "LITE" }
             - { name: QUERY_ENGINE_URL, value: "http://laminar-query-engine:8903" }
             - { name: QUICKWIT_SEARCH_URL, value: "http://laminar-quickwit:7280" }
@@ -159,20 +162,24 @@ spec:
           ports:
             - containerPort: 5667
           env:
-            - { name: DATABASE_URL, value: "postgres://postgres:{{ .Values.postgres.password }}@laminar-postgres:5432/laminar" }
+            - name: DATABASE_URL
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_POSTGRES_URL } }
             - { name: PORT, value: "5667" }
             - { name: BACKEND_URL, value: "http://laminar-app-server:8000" }
             - { name: BACKEND_RT_URL, value: "http://laminar-app-server:8002" }
             - { name: SHARED_SECRET_TOKEN, value: {{ .Values.global.sharedSecretToken | quote }} }
             - { name: NEXTAUTH_URL, value: "https://laminar.asgard.internal" }
-            - { name: NEXTAUTH_SECRET, value: "laminar_asgard_secret" }
+            - name: NEXTAUTH_SECRET
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_NEXTAUTH_SECRET } }
             - { name: NEXT_PUBLIC_URL, value: "https://laminar.asgard.internal" }
             - { name: ENVIRONMENT, value: "LITE" }
             - { name: CLICKHOUSE_URL, value: "http://laminar-clickhouse:8123" }
             - { name: CLICKHOUSE_USER, value: "default" }
-            - { name: CLICKHOUSE_PASSWORD, value: "laminar_ck_secret" }
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_CLICKHOUSE_PASSWORD } }
             - { name: CLICKHOUSE_RO_USER, value: "default" }
-            - { name: CLICKHOUSE_RO_PASSWORD, value: "laminar_ck_secret" }
+            - name: CLICKHOUSE_RO_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_CLICKHOUSE_RO_PASSWORD } }
             - { name: QUICKWIT_SEARCH_URL, value: "http://laminar-quickwit:7280" }
 ---
 apiVersion: v1

--- a/charts/asgard/charts/laminar/templates/postgresql.yaml
+++ b/charts/asgard/charts/laminar/templates/postgresql.yaml
@@ -32,7 +32,8 @@ spec:
           env:
             - { name: POSTGRES_DB, value: "laminar" }
             - { name: POSTGRES_USER, value: "postgres" }
-            - { name: POSTGRES_PASSWORD, value: {{ .Values.postgres.password | quote }} }
+            - name: POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: LAMINAR_POSTGRES_PASSWORD } }
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data

--- a/charts/asgard/charts/mimir/templates/deployment.yaml
+++ b/charts/asgard/charts/mimir/templates/deployment.yaml
@@ -22,18 +22,22 @@ spec:
           ports: [{ containerPort: 8080 }]
           env:
             - { name: PORT, value: "8080" }
-            - { name: DATABASE_URL, value: "mysql://mimir:mimir_password@mariadb.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc:3306/mimir" }
+            - name: DATABASE_URL
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: MIMIR_DATABASE_URL } }
             - { name: QDRANT_URL, value: "http://qdrant.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc:6333" }
             - { name: REDIS_URL, value: "redis://redis.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc:6379" }
             - { name: NEO4J_URI, value: "bolt://neo4j.{{ .Values.global.infraNamespace | default .Release.Namespace }}.svc:7687" }
             - { name: NEO4J_USER, value: neo4j }
-            - { name: NEO4J_PASSWORD, value: REDACTED-PW }
+            - name: NEO4J_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: NEO4J_PASSWORD } }
             - { name: OLLAMA_API_URL, value: "{{ .Values.global.heimdallUrl }}" }
             - { name: OLLAMA_URL, value: {{ .Values.global.ollamaUrl | default .Values.global.heimdallUrl | quote }} }
             - { name: RUST_LOG, value: {{ .Values.global.rustLog | default "info" | quote }} }
-            - { name: YGGDRASIL_ISSUER, value: "http://yggdrasil.{{ .Release.Namespace }}.svc:8080" }
-            - { name: YGGDRASIL_CLIENT_ID, value: "368876822349333070" }
-            - { name: YGGDRASIL_CLIENT_SECRET, value: "jlQ7malc0cl4Ky0XlvgDqhDxXsK6Ogtv3SfSAoexyU12sMxqrIkMFPI6GOgA0Xy6" }
+            - { name: YGGDRASIL_ISSUER, value: {{ .Values.global.yggdrasilIssuerUrl | default (printf "http://yggdrasil.%s.svc:8080" .Release.Namespace) | quote }} }
+            - name: YGGDRASIL_CLIENT_ID
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: YGGDRASIL_CLIENT_ID } }
+            - name: YGGDRASIL_CLIENT_SECRET
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: YGGDRASIL_CLIENT_SECRET } }
           readinessProbe:
             httpGet: { path: /healthz, port: 8080 }
             initialDelaySeconds: 10
@@ -77,10 +81,12 @@ spec:
           env:
             - { name: NEXT_PUBLIC_API_URL, value: "http://mimir-api.{{ .Release.Namespace }}.svc:8080" }
             - { name: MIMIR_API_URL, value: "http://mimir-api.{{ .Release.Namespace }}.svc:8080/api" }
-            - { name: NEXT_PUBLIC_YGGDRASIL_URL, value: "http://yggdrasil.{{ .Release.Namespace }}.svc:8080" }
-            - { name: YGGDRASIL_ISSUER, value: "http://yggdrasil.{{ .Release.Namespace }}.svc:8080" }
-            - { name: YGGDRASIL_CLIENT_ID, value: "368876822349333070" }
-            - { name: YGGDRASIL_CLIENT_SECRET, value: "jlQ7malc0cl4Ky0XlvgDqhDxXsK6Ogtv3SfSAoexyU12sMxqrIkMFPI6GOgA0Xy6" }
+            - { name: NEXT_PUBLIC_YGGDRASIL_URL, value: {{ .Values.global.yggdrasilIssuerUrl | default (printf "http://yggdrasil.%s.svc:8080" .Release.Namespace) | quote }} }
+            - { name: YGGDRASIL_ISSUER, value: {{ .Values.global.yggdrasilIssuerUrl | default (printf "http://yggdrasil.%s.svc:8080" .Release.Namespace) | quote }} }
+            - name: YGGDRASIL_CLIENT_ID
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: YGGDRASIL_CLIENT_ID } }
+            - name: YGGDRASIL_CLIENT_SECRET
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: YGGDRASIL_CLIENT_SECRET } }
           resources:
             requests: { memory: 128Mi, cpu: 100m }
             limits: { memory: 512Mi, cpu: 500m }

--- a/charts/asgard/charts/yggdrasil/templates/deployment.yaml
+++ b/charts/asgard/charts/yggdrasil/templates/deployment.yaml
@@ -26,16 +26,19 @@ spec:
             - { name: ZITADEL_DATABASE_POSTGRES_PORT, value: "5432" }
             - { name: ZITADEL_DATABASE_POSTGRES_DATABASE, value: zitadel }
             - { name: ZITADEL_DATABASE_POSTGRES_USER_USERNAME, value: postgres }
-            - { name: ZITADEL_DATABASE_POSTGRES_USER_PASSWORD, value: yggdrasil-secret }
+            - name: ZITADEL_DATABASE_POSTGRES_USER_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: YGGDRASIL_POSTGRES_PASSWORD } }
             - { name: ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE, value: disable }
             - { name: ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME, value: postgres }
-            - { name: ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD, value: yggdrasil-secret }
+            - name: ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: YGGDRASIL_POSTGRES_PASSWORD } }
             - { name: ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE, value: disable }
             - { name: ZITADEL_EXTERNALSECURE, value: {{ .Values.externalSecure | default "false" | quote }} }
             - { name: ZITADEL_EXTERNALDOMAIN, value: {{ .Values.externalDomain | default "localhost" | quote }} }
             - { name: ZITADEL_EXTERNALPORT, value: {{ .Values.externalPort | default (toString (.Values.nodePort | default 30085)) | quote }} }
             - { name: ZITADEL_FIRSTINSTANCE_ORG_NAME, value: Asgard }
-            - { name: ZITADEL_MASTERKEY, value: {{ .Values.masterKey | default "yggdrasil-masterkey-change-me-ok" | quote }} }
+            - name: ZITADEL_MASTERKEY
+              valueFrom: { secretKeyRef: { name: {{ .Values.global.secretsName | default "asgard-secrets" }}, key: YGGDRASIL_MASTERKEY } }
             - { name: ZITADEL_DEFAULTINSTANCE_LOGINPOLICY_ALLOWREGISTER, value: "false" }
           readinessProbe:
             httpGet:

--- a/charts/asgard/templates/secrets.yaml
+++ b/charts/asgard/templates/secrets.yaml
@@ -41,10 +41,12 @@ stringData:
         (required "secrets.mariadb.password required" .Values.secrets.mariadb.password)
         (.Values.global.infraNamespace | default .Release.Namespace)
         (.Values.infra.mariadb.database | default "mimir") | quote }}
-  NEO4J_PASSWORD: {{ .Values.secrets.neo4j.password | default "REDACTED-PW" | quote }}
+  NEO4J_PASSWORD: {{ required "secrets.neo4j.password is required (Mimir RAG breaks silently if empty)" .Values.secrets.neo4j.password | quote }}
 
   # ── External services / API keys ──
-  HEIMDALL_API_KEY: {{ .Values.secrets.heimdallApiKey | default "" | quote }}
+  # HEIMDALL_API_KEY is required: Bifrost agent runtime cannot reach LLM
+  # gateway without it. Empty string would cause silent 401s at first call.
+  HEIMDALL_API_KEY: {{ required "secrets.heimdallApiKey is required (Bifrost cannot call Heimdall without it)" .Values.secrets.heimdallApiKey | quote }}
   JWT_SECRET: {{ .Values.secrets.jwtSecret | default "" | quote }}
   GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | default "" | quote }}
 

--- a/charts/asgard/templates/secrets.yaml
+++ b/charts/asgard/templates/secrets.yaml
@@ -1,0 +1,62 @@
+{{/*
+🔐 asgard-secrets — Centralized secret store for the umbrella chart.
+
+Two modes:
+
+  1. Helm-managed (default, dev convenience):
+     Set .Values.secrets.create = true and provide values via
+     --set-file or values-prod.yaml. Helm creates this Secret.
+
+  2. Externally-managed (production / Vault / sealed-secrets):
+     Set .Values.secrets.create = false. Operator pre-creates a
+     Secret with the same name (.Values.global.secretsName, default
+     "asgard-secrets") in the release namespace. Chart references it
+     via secretKeyRef without owning it.
+
+Subcharts always reference via secretKeyRef → no plaintext rendering.
+Key naming is UPPERCASE_WITH_UNDERSCORES (env-var style) to match
+existing references in bifrost/mimir-api.
+*/}}
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.secretsName | default "asgard-secrets" }}
+  labels:
+    app.kubernetes.io/name: asgard
+    app.kubernetes.io/managed-by: helm
+type: Opaque
+stringData:
+  # ── Yggdrasil / Zitadel OIDC ──
+  YGGDRASIL_MASTERKEY: {{ required "secrets.yggdrasil.masterKey is required" .Values.secrets.yggdrasil.masterKey | quote }}
+  YGGDRASIL_POSTGRES_PASSWORD: {{ required "secrets.yggdrasil.postgresPassword is required" .Values.secrets.yggdrasil.postgresPassword | quote }}
+  YGGDRASIL_CLIENT_ID: {{ required "secrets.yggdrasil.clientId is required" .Values.secrets.yggdrasil.clientId | quote }}
+  YGGDRASIL_CLIENT_SECRET: {{ required "secrets.yggdrasil.clientSecret is required" .Values.secrets.yggdrasil.clientSecret | quote }}
+
+  # ── Infra databases ──
+  MARIADB_ROOT_PASSWORD: {{ required "secrets.mariadb.rootPassword is required" .Values.secrets.mariadb.rootPassword | quote }}
+  MARIADB_PASSWORD: {{ required "secrets.mariadb.password is required" .Values.secrets.mariadb.password | quote }}
+  MIMIR_DATABASE_URL: {{ printf "mysql://%s:%s@mariadb.%s.svc:3306/%s"
+        (.Values.infra.mariadb.user | default "mimir")
+        (required "secrets.mariadb.password required" .Values.secrets.mariadb.password)
+        (.Values.global.infraNamespace | default .Release.Namespace)
+        (.Values.infra.mariadb.database | default "mimir") | quote }}
+  NEO4J_PASSWORD: {{ .Values.secrets.neo4j.password | default "REDACTED-PW" | quote }}
+
+  # ── External services / API keys ──
+  HEIMDALL_API_KEY: {{ .Values.secrets.heimdallApiKey | default "" | quote }}
+  JWT_SECRET: {{ .Values.secrets.jwtSecret | default "" | quote }}
+  GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | default "" | quote }}
+
+  # ── Laminar (disabled in umbrella; kept for completeness) ──
+  LAMINAR_API_KEY: {{ .Values.secrets.laminar.apiKey | default "" | quote }}
+  LAMINAR_POSTGRES_PASSWORD: {{ .Values.secrets.laminar.postgresPassword | default "" | quote }}
+  LAMINAR_POSTGRES_URL: {{ printf "postgres://postgres:%s@laminar-postgres:5432/laminar" (.Values.secrets.laminar.postgresPassword | default "") | quote }}
+  LAMINAR_CLICKHOUSE_PASSWORD: {{ .Values.secrets.laminar.clickhousePassword | default "" | quote }}
+  LAMINAR_CLICKHOUSE_RO_PASSWORD: {{ .Values.secrets.laminar.clickhouseRoPassword | default "" | quote }}
+  LAMINAR_NEXTAUTH_SECRET: {{ .Values.secrets.laminar.nextauthSecret | default "" | quote }}
+
+  # ── Eir (OpenEMR + Asgard customizations) ──
+  EIR_CLIENT_ID: {{ .Values.secrets.eir.clientId | default "" | quote }}
+  EIR_CLIENT_SECRET: {{ .Values.secrets.eir.clientSecret | default "" | quote }}
+{{- end }}

--- a/charts/asgard/values-dev.yaml
+++ b/charts/asgard/values-dev.yaml
@@ -1,4 +1,15 @@
 # values-dev.yaml — Local development overrides
+#
+# 🔐 Secrets handling:
+#   Dev uses Helm-managed secrets (`secrets.create: true`, the chart default).
+#   Set strong-but-non-prod values for the required keys via:
+#     helm upgrade asgard ./charts/asgard -n asgard \
+#       -f values-dev.yaml \
+#       --set-file secrets.yggdrasil.masterKey=./dev-secrets/masterkey \
+#       (and so on)
+#
+#   To skip per-key flags, drop a values-dev-secrets.yaml (gitignored)
+#   alongside this file with all the `required` values populated.
 global:
   imagePullPolicy: IfNotPresent  # pull from ghcr.io if not present locally
   imagePullSecret: ghcr-secret   # private ghcr.io packages — secret pre-created in asgard ns

--- a/charts/asgard/values-prod.yaml
+++ b/charts/asgard/values-prod.yaml
@@ -1,12 +1,25 @@
 # values-prod.yaml — Production overrides
+#
+# 🔐 Secrets handling:
+#   In prod, the asgard-secrets K8s Secret is managed by Vault Agent
+#   Injector / External Secrets Operator — NOT by Helm. We set
+#   `secrets.create: false` so the chart references the Secret without
+#   owning it. Operator pre-creates `asgard-secrets` in the release ns.
+#
+#   To bootstrap a fresh prod cluster (no operator yet), temporarily
+#   set `secrets.create: true` and pass values via --set-file:
+#     helm upgrade asgard ./charts/asgard -n asgard \
+#       -f values-prod.yaml \
+#       --set secrets.create=true \
+#       --set-file secrets.yggdrasil.masterKey=./prod-secrets/masterkey \
+#       --set-file secrets.yggdrasil.clientSecret=./prod-secrets/oidc-secret \
+#       (and so on for all `required` keys)
 global:
   imagePullPolicy: IfNotPresent
   heimdallUrl: http://heimdall.asgard.internal:8080
 
 secrets:
-  heimdallApiKey: ""  # Set via --set or external-secrets
-  jwtSecret: ""
-  geminiApiKey: ""
+  create: false  # Externally-managed (Vault / ESO / sealed-secrets)
 
 bifrost:
   image: ghcr.io/megawiz-dev-team/bifrost:latest

--- a/charts/asgard/values.yaml
+++ b/charts/asgard/values.yaml
@@ -4,6 +4,10 @@
 global:
   namespace: asgard
   infraNamespace: asgard-infra  # mariadb/postgres/qdrant/redis/neo4j live here
+  # Name of the K8s Secret that subcharts reference via secretKeyRef.
+  # Default "asgard-secrets" — overridable for multi-tenant or
+  # per-env Secret naming (e.g. ESO + cluster-scoped Secret store).
+  secretsName: asgard-secrets
   # CI-driven image flow: pulls from ghcr.io built by Build-and-Push workflow
   imageRegistry: ghcr.io/megawiz-dev-team
   imagePullPolicy: IfNotPresent
@@ -17,26 +21,73 @@ global:
   logLevel: info
 
 # ── Shared Secrets ──
+# All secrets are stored in a central K8s Secret resource named
+# `asgard-secrets`. Subcharts reference values via secretKeyRef.
+#
+# Two modes:
+#   • create: true   — Helm manages the Secret from values below (dev/test).
+#                      Provide values via --set, --set-file, or values-*.yaml.
+#                      Plaintext defaults are intentionally absent so empty
+#                      strings/missing values fail fast via `required`.
+#   • create: false  — Operator pre-creates a Secret with the same name
+#                      "asgard-secrets" in the release namespace (prod /
+#                      Vault Agent Injector / Sealed Secrets / ESO).
+#
+# To rotate any secret in the running cluster:
+#   1. Update the upstream system (Zitadel admin UI, Postgres, etc.)
+#   2. kubectl create secret generic asgard-secrets --from-literal=... \
+#        --dry-run=client -o yaml | kubectl apply -f - -n asgard
+#   3. Restart consumers: kubectl rollout restart deploy -n asgard
+#
+# See docs/security/SECRETS.md for the full rotation runbook.
 secrets:
+  create: true
+
+  # Yggdrasil / Zitadel OIDC
+  yggdrasil:
+    masterKey: ""           # ZITADEL_MASTERKEY (rotation invalidates all sessions)
+    postgresPassword: ""    # ZITADEL_DATABASE_POSTGRES_USER_PASSWORD
+    clientId: ""            # OIDC client ID (registered in Zitadel)
+    clientSecret: ""        # OIDC client secret (regen in Zitadel admin UI)
+
+  # Infra databases
+  mariadb:
+    rootPassword: ""
+    password: ""            # mimir DB user password
+  neo4j:
+    password: ""
+
+  # Optional — external services
   heimdallApiKey: ""
   jwtSecret: ""
   geminiApiKey: ""
   geminiBaseUrl: ""
   geminiModel: ""
 
+  # Eir (OpenEMR + Asgard agent integration)
+  eir:
+    clientId: ""
+    clientSecret: ""
+
+  # Laminar (Sága) — disabled in umbrella; kept for completeness.
+  laminar:
+    apiKey: ""
+    postgresPassword: ""
+    clickhousePassword: ""
+    clickhouseRoPassword: ""
+    nextauthSecret: ""
+
 # ── Infrastructure ──
+# DB credentials are NOT defined here — see `secrets:` section above.
+# Only non-sensitive structural config (sizes, db names, storage) below.
 infra:
   enabled: true
-  laminarApiKey: "UZfUPh7uU6Z75uQeeVpuED3HpjcJM3BBL7UnYIlkd18AseLjvrjIVnU9MoXGptVC"
   mariadb:
-    rootPassword: root
     database: mimir
     user: mimir
-    password: REDACTED-PW
     storage: 10Gi
   postgres:
     user: postgres
-    password: yggdrasil-secret
     database: zitadel
     storage: 5Gi
   redis:
@@ -45,10 +96,10 @@ infra:
     storage: 10Gi
 
 # ── Auth ──
+# masterKey + postgres password come from the asgard-secrets K8s Secret.
 yggdrasil:
   enabled: true
   image: ghcr.io/zitadel/zitadel:v2.71.6
-  masterKey: yggdrasil-masterkey-change-me-ok
   nodePort: 30085
   externalSecure: "false"
   externalDomain: localhost

--- a/docs/security/SECRETS.md
+++ b/docs/security/SECRETS.md
@@ -1,0 +1,139 @@
+# 🔐 Asgard Secret Management
+
+> Status: **Sprint 51e — initial migration to K8s Secrets**.
+> Long-term plan: Vault Agent Injector (Hashicorp Vault is already in cluster).
+
+## Where secrets live now
+
+All chart-managed secrets are centralized in a single K8s Secret named
+`asgard-secrets` (override via `global.secretsName`). Subcharts reference
+values via `secretKeyRef` — no plaintext rendering in deployment manifests.
+
+| Key | Used by | Source of truth |
+|---|---|---|
+| `YGGDRASIL_MASTERKEY` | Yggdrasil (Zitadel) | Generated once during install. **Rotation invalidates all sessions.** |
+| `YGGDRASIL_POSTGRES_PASSWORD` | Yggdrasil + infra Postgres | Generated once. Rotate via Postgres `ALTER ROLE`. |
+| `YGGDRASIL_CLIENT_ID` | Mimir + Bifrost | Created in Zitadel admin UI per OIDC client. |
+| `YGGDRASIL_CLIENT_SECRET` | Mimir + Bifrost | Regenerated in Zitadel admin UI ("Reset Secret"). |
+| `MARIADB_ROOT_PASSWORD` / `MARIADB_PASSWORD` | infra MariaDB + Mimir | Generated once. Rotate via MariaDB `SET PASSWORD`. |
+| `MIMIR_DATABASE_URL` | Mimir API | Derived from MARIADB_PASSWORD; redepoy mimir after rotation. |
+| `NEO4J_PASSWORD` | Mimir API + Neo4j init | Set during Neo4j first-boot; rotate via cypher `ALTER USER`. |
+| `HEIMDALL_API_KEY` | Bifrost + Mimir | Issued by Heimdall (host-side); rotate by re-running Heimdall key-gen. |
+| `EIR_CLIENT_ID` / `EIR_CLIENT_SECRET` | Eir Gateway → Bifrost agent | OIDC app in Zitadel. |
+
+Disabled but committed (will be active when laminar re-enabled):
+
+`LAMINAR_API_KEY`, `LAMINAR_POSTGRES_PASSWORD`, `LAMINAR_POSTGRES_URL`,
+`LAMINAR_CLICKHOUSE_PASSWORD`, `LAMINAR_CLICKHOUSE_RO_PASSWORD`,
+`LAMINAR_NEXTAUTH_SECRET`.
+
+## Two install modes
+
+### Helm-managed (dev / test / lab cluster)
+
+```yaml
+# values-dev.yaml
+secrets:
+  create: true
+  yggdrasil:
+    masterKey: <random 32-byte hex>
+    postgresPassword: <strong random>
+    clientId: <from Zitadel UI>
+    clientSecret: <from Zitadel UI>
+  mariadb:
+    rootPassword: <strong random>
+    password: <strong random>
+  # ... rest as needed
+```
+
+```bash
+helm upgrade --install asgard ./charts/asgard \
+  -n asgard \
+  -f values-dev.yaml
+```
+
+### Externally-managed (prod / Vault / sealed-secrets / ESO)
+
+```yaml
+# values-prod.yaml
+secrets:
+  create: false   # don't let Helm own the Secret
+```
+
+Operator pre-creates `asgard-secrets` in the release namespace by whichever
+mechanism (Vault Agent Injector → annotations on Deployment, External
+Secrets Operator → `ExternalSecret` CR, etc.).
+
+## Rotation runbook
+
+### YGGDRASIL_CLIENT_SECRET (most common rotation)
+
+When a client secret is suspected leaked or as part of routine rotation:
+
+1. **Zitadel admin UI** → Project → Application → click "Reset Client Secret"
+2. Copy the new secret immediately (shown only once)
+3. Patch the K8s Secret:
+   ```bash
+   kubectl patch secret asgard-secrets -n asgard \
+     --type='json' \
+     -p='[{"op":"replace","path":"/data/YGGDRASIL_CLIENT_SECRET","value":"'$(echo -n "<NEW_SECRET>" | base64)'"}]'
+   ```
+4. Restart consumers (env vars are evaluated at pod start):
+   ```bash
+   kubectl rollout restart deploy/mimir-api deploy/mimir-dashboard deploy/bifrost -n asgard
+   ```
+5. Verify login flow at https://sso.asgard.internal still works.
+
+### Database password rotation
+
+Order matters — change DB-side first, then K8s, then restart consumers:
+
+```bash
+# 1. Change in DB
+kubectl exec -n asgard-infra mariadb-0 -- mariadb -u root -p \
+  -e "ALTER USER 'mimir'@'%' IDENTIFIED BY '<NEW_PW>'; FLUSH PRIVILEGES;"
+
+# 2. Update K8s Secret
+kubectl create secret generic asgard-secrets -n asgard \
+  --from-literal=MARIADB_PASSWORD="<NEW_PW>" \
+  --from-literal=MIMIR_DATABASE_URL="mysql://mimir:<NEW_PW>@mariadb.asgard-infra.svc:3306/mimir" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# 3. Restart consumers
+kubectl rollout restart deploy/mimir-api -n asgard
+```
+
+### Bulk seed (fresh cluster)
+
+```bash
+kubectl create secret generic asgard-secrets -n asgard \
+  --from-literal=YGGDRASIL_MASTERKEY="$(openssl rand -hex 32)" \
+  --from-literal=YGGDRASIL_POSTGRES_PASSWORD="$(openssl rand -base64 32)" \
+  --from-literal=YGGDRASIL_CLIENT_ID="<from-zitadel-ui>" \
+  --from-literal=YGGDRASIL_CLIENT_SECRET="<from-zitadel-ui>" \
+  --from-literal=MARIADB_ROOT_PASSWORD="$(openssl rand -base64 24)" \
+  --from-literal=MARIADB_PASSWORD="$(openssl rand -base64 24)" \
+  --from-literal=NEO4J_PASSWORD="$(openssl rand -base64 24)" \
+  --from-literal=HEIMDALL_API_KEY="<from-heimdall-keygen>" \
+  --from-literal=EIR_CLIENT_ID="<from-zitadel-ui>" \
+  --from-literal=EIR_CLIENT_SECRET="<from-zitadel-ui>"
+```
+
+## Security incident response (post-leak)
+
+If a secret is committed to a public repo (e.g. as happened pre-Sprint 51e):
+
+1. **Treat it as burned** — git scrub doesn't help; assume forks/clones cached it.
+2. Rotate the upstream credential **first** (Zitadel UI / DB / Heimdall).
+3. Update K8s Secret (patch or recreate).
+4. Restart all consumers.
+5. Audit access logs for unusual activity in the rotation window.
+6. Open a private GitHub Security Advisory (no public issue) describing scope.
+
+## What's still on the roadmap
+
+- Vault Agent Injector (annotation-based) — eliminate static K8s Secrets entirely
+- ExternalSecrets Operator + Vault as backend
+- SOPS encrypted values files for GitOps deploys
+
+These are tracked in [Asgard issue #TODO](https://github.com/MegaWiz-Dev-Team/Asgard/issues) as a follow-up to the Sprint 51e refactor.

--- a/k8s/01-infra/postgres/deployment.yaml
+++ b/k8s/01-infra/postgres/deployment.yaml
@@ -69,13 +69,23 @@ spec:
     - port: 5432
       targetPort: 5432
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres-secret
-  namespace: asgard-infra
-type: Opaque
-stringData:
-  POSTGRES_USER: postgres
-  POSTGRES_PASSWORD: yggdrasil-secret
-  POSTGRES_DB: zitadel
+# NOTE: This Secret is no longer applied from git. Create out-of-band:
+#
+#   kubectl create secret generic postgres-secret -n asgard-infra \
+#     --from-literal=POSTGRES_USER=postgres \
+#     --from-literal=POSTGRES_PASSWORD="$(cat /path/to/password)" \
+#     --from-literal=POSTGRES_DB=zitadel
+#
+# Kept here as a documented schema only. See docs/security/SECRETS.md
+# for the full rotation runbook.
+#
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: postgres-secret
+#   namespace: asgard-infra
+# type: Opaque
+# stringData:
+#   POSTGRES_USER: postgres
+#   POSTGRES_PASSWORD: <REDACTED — see runbook>
+#   POSTGRES_DB: zitadel

--- a/k8s/02-services/eir/eir.yaml
+++ b/k8s/02-services/eir/eir.yaml
@@ -196,9 +196,21 @@ spec:
             - name: OPENEMR_URL
               value: "https://eir.asgard.svc"
             - name: CLIENT_ID
-              value: "YUeXbce0jptSbSk2vM3TiWNPe98EvJG9gh1Znt_8DdU"
+              valueFrom:
+                secretKeyRef:
+                  name: asgard-secrets
+                  key: EIR_CLIENT_ID
             - name: CLIENT_SECRET
-              value: "xWVKMnOb3LAb5-lF83Pdxfxu2uCsSF3iimB56BpCPt8eu1Ml1AOJKuyTxSqzcdLiSAOKYvvXYiABPIlLsD4HJQ"
+              valueFrom:
+                secretKeyRef:
+                  name: asgard-secrets
+                  key: EIR_CLIENT_SECRET
+            - name: TENANT_ID
+              value: "asgard_medical"
+            - name: DEFAULT_AGENT_ID
+              value: "28"
+            - name: BIFROST_URL
+              value: "http://bifrost:8100"
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/02-services/mimir-api/deployment.yaml
+++ b/k8s/02-services/mimir-api/deployment.yaml
@@ -25,8 +25,9 @@ spec:
           env:
             - name: PORT
               value: "8080"
-            - name: DATABASE_URL
-              value: mysql://mimir:REDACTED-PW@mariadb.asgard-infra.svc:3306/mimir
+            # DATABASE_URL + NEO4J_PASSWORD now come from envFrom: asgard-secrets
+            # (defined below). Setting them here would override envFrom values
+            # since `env` takes precedence over `envFrom` for matching keys.
             - name: QDRANT_URL
               value: http://qdrant.asgard-infra.svc:6333
             - name: REDIS_URL
@@ -35,8 +36,6 @@ spec:
               value: bolt://neo4j.asgard-infra.svc:7687
             - name: NEO4J_USER
               value: neo4j
-            - name: NEO4J_PASSWORD
-              value: REDACTED-PW
             - name: USE_NEO4J_GRAPH
               value: "true"
             - name: OLLAMA_API_URL

--- a/k8s/02-services/mimir-api/deployment.yaml
+++ b/k8s/02-services/mimir-api/deployment.yaml
@@ -48,8 +48,8 @@ spec:
             - name: HEIMDALL_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: mimir-api-secrets
-                  key: heimdall-api-key
+                  name: asgard-secrets
+                  key: HEIMDALL_API_KEY
             - name: EMBEDDING_HOST
               value: host.docker.internal
             - name: EMBEDDING_PORT

--- a/k8s/02-services/yggdrasil/deployment.yaml
+++ b/k8s/02-services/yggdrasil/deployment.yaml
@@ -32,13 +32,19 @@ spec:
             - name: ZITADEL_DATABASE_POSTGRES_USER_USERNAME
               value: postgres
             - name: ZITADEL_DATABASE_POSTGRES_USER_PASSWORD
-              value: yggdrasil-secret
+              valueFrom:
+                secretKeyRef:
+                  name: asgard-secrets
+                  key: YGGDRASIL_POSTGRES_PASSWORD
             - name: ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE
               value: disable
             - name: ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME
               value: postgres
             - name: ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD
-              value: yggdrasil-secret
+              valueFrom:
+                secretKeyRef:
+                  name: asgard-secrets
+                  key: YGGDRASIL_POSTGRES_PASSWORD
             - name: ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE
               value: disable
             - name: ZITADEL_EXTERNALSECURE
@@ -50,7 +56,10 @@ spec:
             - name: ZITADEL_FIRSTINSTANCE_ORG_NAME
               value: Asgard
             - name: ZITADEL_MASTERKEY
-              value: yggdrasil-masterkey-change-me-ok
+              valueFrom:
+                secretKeyRef:
+                  name: asgard-secrets
+                  key: YGGDRASIL_MASTERKEY
             - name: ZITADEL_DEFAULTINSTANCE_LOGINPOLICY_ALLOWREGISTER
               value: "false"
           readinessProbe:


### PR DESCRIPTION
## ⚠️ Security PR — read carefully

Asgard repo is **public** (per Sprint 51d open-core go-live). Several chart
templates + k8s manifests embedded plaintext secrets for months. **All committed
secrets must be considered burned.**

This PR moves all secrets to a centralized K8s Secret (`asgard-secrets`) and
documents rotation. **Merging alone does not fix the leak — operator must rotate.**

## What changed

### New
- `charts/asgard/templates/secrets.yaml` — single Secret resource for the umbrella chart
- `docs/security/SECRETS.md` — key inventory + rotation runbook + incident response

### Modified (refactored to `secretKeyRef`)

| File | Secrets removed |
|---|---|
| `charts/asgard/charts/mimir/templates/deployment.yaml` | YGGDRASIL_CLIENT_SECRET (×2), DATABASE_URL, NEO4J_PASSWORD |
| `charts/asgard/charts/yggdrasil/templates/deployment.yaml` | ZITADEL_MASTERKEY, postgres password (×2) |
| `charts/asgard/charts/infra/templates/all.yaml` | MariaDB root + user, Postgres password |
| `charts/asgard/charts/laminar/templates/{laminar-core,postgresql,clickhouse}.yaml` | NEXTAUTH_SECRET, clickhouse pw (×4), postgres pw |
| `k8s/02-services/yggdrasil/deployment.yaml` | masterkey, postgres pw (×2) |
| `k8s/02-services/eir/eir.yaml` | CLIENT_SECRET (kept TENANT_ID/DEFAULT_AGENT_ID/BIFROST_URL additions) |
| `k8s/01-infra/postgres/deployment.yaml` | committed K8s Secret commented out |
| `charts/asgard/values.yaml` | restructured `secrets:` section, removed plaintext defaults from `infra:` |

## Two install modes

```yaml
# Helm-managed (dev/test)
secrets:
  create: true
  yggdrasil: { masterKey: ..., postgresPassword: ..., clientId: ..., clientSecret: ... }
  mariadb: { rootPassword: ..., password: ... }

# Externally-managed (prod / Vault / ESO / sealed-secrets)
secrets:
  create: false
```

## Operator action required (BEFORE OR IMMEDIATELY AFTER MERGE)

1. **Rotate** all secrets (the committed ones are burned):
   - Zitadel masterkey (clusterboot reset — invalidates all sessions)
   - Zitadel OIDC client secrets (admin UI → Reset)
   - Postgres + MariaDB passwords (DB ALTER USER)
   - Eir Gateway OIDC client secret
2. **Bulk-seed** the new K8s Secret per docs/security/SECRETS.md
3. `helm upgrade asgard ./charts/asgard -n asgard -f values-prod.yaml`
4. `kubectl rollout restart deploy -n asgard` to pick up new env vars
5. Verify mimir login, eir gateway auth still works

## Aligns with user's parallel work

User had already started the same migration in bifrost + mimir-api (UPPERCASE
keys, `global.secretsName` override pattern). This PR preserves that and
extends it to all remaining plaintext-secret sites.

## Test plan

- [ ] `helm template ./charts/asgard --set 'secrets.yggdrasil.masterKey=test' --set 'secrets.yggdrasil.postgresPassword=test' --set 'secrets.yggdrasil.clientId=test' --set 'secrets.yggdrasil.clientSecret=test' --set 'secrets.mariadb.rootPassword=test' --set 'secrets.mariadb.password=test'` renders without errors
- [ ] `required` directives fail with clear message when values omitted
- [ ] `helm upgrade` on dev cluster — pods come up, login works
- [ ] `secrets.create: false` mode — chart references existing Secret without owning it

Part of Asgard Sprint 51e — Path 1 (Security first / Option B refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)