### PR TITLE
chore(k8s): switch eir + hermodr to ghcr.io images

### DIFF
--- a/k8s/02-services/eir/eir.yaml
+++ b/k8s/02-services/eir/eir.yaml
@@ -29,8 +29,8 @@ spec:
     spec:
       initContainers:
         - name: prep-sites
-          image: asgard-eir:latest
-          imagePullPolicy: Never
+          image: ghcr.io/megawiz-dev-team/asgard-eir:latest
+          imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c
@@ -85,8 +85,8 @@ spec:
               mountPath: /ssl-keys
       containers:
         - name: eir
-          image: asgard-eir:latest
-          imagePullPolicy: Never
+          image: ghcr.io/megawiz-dev-team/asgard-eir:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
             - containerPort: 443
@@ -186,8 +186,8 @@ spec:
     spec:
       containers:
         - name: gateway
-          image: asgard-eir-gateway:latest
-          imagePullPolicy: Never
+          image: ghcr.io/megawiz-dev-team/eir-gateway:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8300
           env:
@@ -245,8 +245,8 @@ spec:
     spec:
       containers:
         - name: hermodr
-          image: asgard-hermodr:latest
-          imagePullPolicy: Never
+          image: ghcr.io/megawiz-dev-team/asgard-hermodr:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV
               value: "production"

--- a/k8s/02-services/eir/eir.yaml
+++ b/k8s/02-services/eir/eir.yaml
@@ -27,10 +27,12 @@ spec:
       labels:
         app: eir
     spec:
+      imagePullSecrets:
+        - name: ghcr-secret
       initContainers:
         - name: prep-sites
           image: ghcr.io/megawiz-dev-team/asgard-eir:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - sh
             - -c
@@ -86,7 +88,7 @@ spec:
       containers:
         - name: eir
           image: ghcr.io/megawiz-dev-team/asgard-eir:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 80
             - containerPort: 443
@@ -184,10 +186,12 @@ spec:
       labels:
         app: eir-gateway
     spec:
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: gateway
           image: ghcr.io/megawiz-dev-team/eir-gateway:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 8300
           env:
@@ -243,10 +247,12 @@ spec:
       labels:
         app: hermodr-eir
     spec:
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: hermodr
           image: ghcr.io/megawiz-dev-team/asgard-hermodr:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: NODE_ENV
               value: "production"

--- a/k8s/02-services/remaining-services.yaml
+++ b/k8s/02-services/remaining-services.yaml
@@ -18,8 +18,8 @@ spec:
     spec:
       containers:
         - name: hermodr
-          image: asgard-hermodr-yggdrasil:latest
-          imagePullPolicy: Never
+          image: ghcr.io/megawiz-dev-team/hermodr-yggdrasil:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8090
           env:

--- a/k8s/02-services/remaining-services.yaml
+++ b/k8s/02-services/remaining-services.yaml
@@ -16,10 +16,12 @@ spec:
       labels:
         app: hermodr
     spec:
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: hermodr
           image: ghcr.io/megawiz-dev-team/hermodr-yggdrasil:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 8090
           env:

--- a/k8s/04-security/tyr/05-hermodr-bridge.yaml
+++ b/k8s/04-security/tyr/05-hermodr-bridge.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: hermodr
-          image: asgard-hermodr:latest
+          image: ghcr.io/megawiz-dev-team/asgard-hermodr:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: SERVICE_NAME

--- a/k8s/04-security/tyr/05-hermodr-bridge.yaml
+++ b/k8s/04-security/tyr/05-hermodr-bridge.yaml
@@ -23,10 +23,12 @@ spec:
       labels:
         app: hermodr-wazuh
     spec:
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: hermodr
           image: ghcr.io/megawiz-dev-team/asgard-hermodr:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SERVICE_NAME
               value: "wazuh"


### PR DESCRIPTION
## Summary

After Eir polyrepo CI (PR #3, merged) publishes \`asgard-eir\` + \`eir-gateway\` and Hermodr polyrepo CI (PR #3, merged) publishes \`asgard-hermodr\` + \`hermodr-yggdrasil\` to ghcr.io, k8s manifests no longer need local docker builds.

| Manifest | Before | After |
|---|---|---|
| \`k8s/02-services/eir/eir.yaml\` (init container + main container) | \`asgard-eir:latest\` | \`ghcr.io/megawiz-dev-team/asgard-eir:latest\` |
| \`k8s/02-services/eir/eir.yaml\` (gateway) | \`asgard-eir-gateway:latest\` | \`ghcr.io/megawiz-dev-team/eir-gateway:latest\` |
| \`k8s/02-services/eir/eir.yaml\` (hermodr-eir bridge) | \`asgard-hermodr:latest\` | \`ghcr.io/megawiz-dev-team/asgard-hermodr:latest\` |
| \`k8s/02-services/remaining-services.yaml\` (hermodr-yggdrasil) | \`asgard-hermodr-yggdrasil:latest\` | \`ghcr.io/megawiz-dev-team/hermodr-yggdrasil:latest\` |
| \`k8s/04-security/tyr/05-hermodr-bridge.yaml\` (wazuh bridge) | \`asgard-hermodr:latest\` | \`ghcr.io/megawiz-dev-team/asgard-hermodr:latest\` |

Also flips \`imagePullPolicy: Never\` → \`IfNotPresent\` (Never was forced because the local-only image had no remote source).

## Why

Per Sprint 51e Lane C goal: fix Eir 503 errors caused by local docker build dependency. With ghcr.io publishing in place, fresh cluster nodes (or evicted pods on different nodes) can now pull the images on demand.

## Verified CI publishes

- ✅ Eir Build run 25634031313 — pushed \`asgard-eir\` + \`eir-gateway\`
- ✅ Hermodr Build run 25634030452 — pushed \`hermodr\` + \`asgard-hermodr\` + \`hermodr-yggdrasil\`

## Operator action after merge

Cluster needs the \`ghcr-secret\` imagePullSecret in target namespaces (if packages are private). Test deploy:

\`\`\`bash
kubectl apply -f k8s/02-services/eir/eir.yaml -n asgard
kubectl apply -f k8s/02-services/remaining-services.yaml -n asgard-services
kubectl apply -f k8s/04-security/tyr/05-hermodr-bridge.yaml -n wazuh

kubectl rollout status deploy/eir deploy/eir-gateway deploy/hermodr-eir -n asgard
\`\`\`

If pull errors: confirm \`ghcr-secret\` exists in each target ns, or make the ghcr packages public.

## Out of scope (left for follow-up sprint)

Other services still using local docker builds:
- mimir-api, mimir-dashboard, bifrost, forseti, fenrir, vardr, ratatoskr, mjolnir, pageindex, llmgoat

These work fine today (local docker workflow); switching them is a separate cleanup task.

## Test plan

- [ ] PR merge → kubectl apply on dev cluster → pods come up
- [ ] \`kubectl describe pod eir-gateway-...\` shows ghcr.io image pulled successfully
- [ ] \`https://ehr.asgard.internal\` → no more 503

Closes Sprint 51e Lane C (polyrepo CI close-out + Eir 503 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)