### PR TITLE
docs(adr-006): revise to 3-tier per B-50a.2 — drop chandra Tier 1a

### DIFF
--- a/docs/architecture/ADR-006-Syn-OCR-Stack.md
+++ b/docs/architecture/ADR-006-Syn-OCR-Stack.md
@@ -1,9 +1,22 @@
-# ADR-006 — Syn S1 OCR Stack: 4-tier hybrid (chandra + PaddleOCR + Gemini Flash + Pro)
+# ADR-006 — Syn S1 OCR Stack: 3-tier hybrid (PaddleOCR + Typhoon-OCR + Gemini Flash + Pro)
 
-**Status:** Accepted
-**Date:** 2026-05-08
+**Status:** Accepted (revised 2026-05-08 per B-50a.2)
+**Date:** 2026-05-08 (initial) / 2026-05-08 (revision)
 **Sprint:** 50 (Syn S1 — OCR Foundation)
 **Related ADRs:** ADR-007 (Skuggi PII Guardrail) — gates the cloud tiers below.
+
+## Revision summary (B-50a.2)
+
+The original 4-tier decision included a `chandra-local` Tier 1a for handwriting on the assumption it was a lightweight (~80MB) EasyOCR-class engine. When `chandra-ocr` v0.2.0 actually shipped in 2026-05, it turned out to be a **10.6 GB VLM** on Qwen3.5-VL — same weight class as Tier 1c Typhoon-OCR.
+
+Bench (B-50a.2, 5 synthetic Thai handwritten clinical notes):
+
+| Engine | CER median | Latency median |
+|---|---|---|
+| `chandra-local` (EasyOCR-paragraph 1.7.2) | 0.193 | 8.2 s |
+| `typhoon-ocr-local` (1.5-3B via Ollama)   | **0.000** | **2.9 s** |
+
+Typhoon dominates by a wide margin. Conclusion: **collapse 4-tier → 3-tier**, drop the `chandra-local` Tier 1a entirely, reroute `doc_type=handwriting` to Typhoon. Full assessment + bench in [Syn/docs/B-50a.2_chandra_assessment_2026-05-08.md](https://github.com/MegaWiz-Dev-Team/Syn/blob/main/docs/B-50a.2_chandra_assessment_2026-05-08.md).
 
 ## Context
 
@@ -25,23 +38,25 @@ points needed.
 
 ## Decision
 
-**4-tier hybrid stack with local-first default + opt-in cloud premium.**
+**3-tier hybrid stack with local-first default + opt-in cloud premium.**
 
 | Tier | Engine | License | Cost | Use case |
 |:---:|---|---|---|---|
-| **1a** | `datalab-to/chandra` (10.5k ⭐) | Apache 2.0 | $0 (local) | Handwriting, complex tables, forms |
-| **1b** | `PaddleOCR` PP-OCRv4 (~50k ⭐) | Apache 2.0 | $0 (local) | Thai stock print, fast latency |
+| **1b** | `PaddleOCR` PP-OCRv4 (~50k ⭐) | Apache 2.0 | $0 (local) | Thai stock print, forms, fast latency |
+| **1c** | `Typhoon-OCR 1.5-3B` (Ollama-local VLM) | Apache 2.0 | $0 (local) | Handwriting, complex tables, mixed-language, quality-uncertain |
 | **2** | `gemini-3-flash` | proprietary API | ~$0.001-0.005 / page | Multilingual fallback when local confidence low |
 | **3** | `gemini-3.1-pro` | proprietary API | ~$0.05-0.20 / page | High-stakes (legal, critical lab, complex layouts) |
 
 **Smart router** (rule-based, evaluated in order, first match wins):
 
-1. PHI-strict tenant flag set → LOCAL only (Tier 1a/1b)
+1. PHI-strict tenant flag set → LOCAL only (Tier 1b / 1c)
 2. Per-call `--engine` override → that engine
-3. Document type known (handwriting / complex_table / form / thai_print) → 1a or 1b
-4. Document size >5p OR marked "critical"/"legal" → Tier 3 (Pro) IF tenant `cloud_pro_enabled` else Tier 2 (Flash) else 1a best-effort
+3. Document type known: `handwriting / complex_table` → 1c Typhoon; `form / thai_print` → 1b PaddleOCR
+4. Document size >5p OR marked "critical"/"legal" → Tier 3 (Pro) IF tenant `cloud_pro_enabled` else Tier 2 (Flash) else 1c best-effort
 5. Local engine confidence <0.70 → Tier 2 (Flash) IF `cloud_flash_enabled` else local + warn
-6. Default → 1a chandra → fallback 1b PaddleOCR
+6. Default → 1b PaddleOCR → fallback 1c Typhoon
+
+**Note on tier numbering:** the legacy `1a` slot (chandra-local) is retired and not reissued — `1b` / `1c` keep their numbers for audit-log + dashboard continuity. New engines added in future sprints get `1d`, `1e`, etc.
 
 ## Options considered
 
@@ -66,13 +81,21 @@ points needed.
 - ❌ TrOCR Apache 2.0 but heavy GPU footprint; Tesseract Apache 2.0 but Thai accuracy noticeably worse than PaddleOCR PP-OCRv4
 - **Rejected:** weaker Thai support
 
-### E. **4-tier hybrid (CHOSEN)**
+### E. **4-tier hybrid (originally chosen, superseded)**
 - ✅ Local-first default (covers ~85% of routine docs at $0)
 - ✅ Opt-in cloud for the 15% hard cases (controlled cost)
 - ✅ All-Apache-2.0 local stack preserves Commercial moat
 - ✅ Cloud tier reuses existing Heimdall step-up router pattern (Sprint 36)
 - 🟡 Two services to maintain locally (chandra + PaddleOCR); router complexity
 - 🟡 chandra is newer (~1 yr); accept as monitored risk
+- **Superseded by F** after B-50a.2 bench showed Typhoon-OCR Tier 1c outperforms chandra-local on handwriting (CER 0.000 vs 0.193).
+
+### F. **3-tier hybrid (CHOSEN, current)**
+- ✅ Same local-first / cloud-opt-in shape as E
+- ✅ One fewer local service to maintain (drop chandra-sidecar)
+- ✅ Typhoon-OCR (already deployed for B-50a.3) absorbs the handwriting/quality-uncertain workload at higher accuracy AND lower latency than chandra-local would have provided
+- ✅ Removes "two adjacent VLMs at Tier 1a + Tier 1c doing similar work" smell
+- 🟡 Single-engine handwriting risk — if Typhoon regresses, no second-opinion local engine. Mitigation: B-50h benchmark (real Thai handwriting from clinician partner) + Tier 2 Flash escalation on confidence drop.
 
 ## Consequences
 
@@ -83,20 +106,19 @@ points needed.
 - **Reusable pattern** — same Heimdall step-up route works for Sprint 52 Sága (STT) and Sprint 53 vision LLM
 
 ### Negative
-- **2 local services to maintain** — chandra + PaddleOCR drift, version pinning, ops
+- **2 local services to maintain** — PaddleOCR + Typhoon-OCR drift, version pinning, ops (one fewer than 4-tier — chandra retired)
 - **Router complexity** — rule-based v0 may need ML-based v1 (deferred)
-- **chandra Thai accuracy unknown** — no explicit Thai model; mitigation via B-50h benchmark; if Thai CER >20% on chandra, demote to handwriting/tables only
+- **Single handwriting engine** — Typhoon-OCR is the only local option for handwriting. If it regresses, no local fallback. Mitigation: confidence-gated cloud Flash escalation (rule 5) + quarterly bench.
 
 ### Mitigations
-- B-50h test set: 30 Thai docs (10 print, 10 handwriting, 10 table) × 4 engines = 120-cell benchmark grid before sprint close
+- B-50h test set: 30 Thai docs (10 print, 10 handwriting, 10 table) × 3 engines = 90-cell benchmark grid before sprint close
 - B-50l tenant settings include `pii_mode` (chained to ADR-007 Skuggi) before any cloud call goes live
 - B-50m cost guard middleware enforces monthly per-tenant cap
-- Quarterly stack review: if chandra matures + Thai support solid → drop PaddleOCR (Sprint 53+)
-- If clinician feedback shows chandra inadequate → consider buying Datalab commercial license for surya/marker
+- Quarterly stack review: if Typhoon Thai accuracy regresses → re-evaluate adding back a handwriting-specific engine (e.g. mature chandra-ocr-2 with multistage Dockerfile if image size mitigations are workable)
 
 ## Future revisits
 
-- **2026-Q3:** if chandra Thai accuracy ≥ PaddleOCR after maturity → simplify to chandra-only local
+- **2026-Q3:** revisit chandra-ocr-2 if (a) image size mitigations land (multistage Dockerfile, model on shared volume) AND (b) bench shows chandra beats Typhoon on a specific document class. Until then, Tier 1a stays retired.
 - **2026-Q4:** if Sprint 52 Sága needs reversible PII (voice context) → upgrade Skuggi v1 with HSM keys
 - **2027:** if Asgard Commercial moat sufficiently established + Datalab commercial pricing reasonable → re-evaluate surya/marker
 
@@ -104,6 +126,8 @@ points needed.
 
 - Sprint 50 backlog: [`Mimir/docs/03_implementation_plans/03_14_Local_LLM_Optimization_Sprints.md`](../../../Mimir/docs/03_implementation_plans/03_14_Local_LLM_Optimization_Sprints.md) Sprint 50 section
 - ADR-007 Skuggi (gates cloud tiers): [`ADR-007-Skuggi-PII-Guardrail.md`](ADR-007-Skuggi-PII-Guardrail.md)
-- chandra: https://github.com/datalab-to/chandra (Apache 2.0)
+- B-50a.2 chandra integration assessment + bench: [`Syn/docs/B-50a.2_chandra_assessment_2026-05-08.md`](https://github.com/MegaWiz-Dev-Team/Syn/blob/main/docs/B-50a.2_chandra_assessment_2026-05-08.md)
+- Typhoon-OCR: https://github.com/scb-10x/typhoon-ocr (Apache 2.0)
 - PaddleOCR: https://github.com/PaddlePaddle/PaddleOCR (Apache 2.0)
+- chandra (retired Tier 1a): https://github.com/datalab-to/chandra (Apache 2.0)
 - Asgard roadmap (Syn → Sága → Visual BMI sequence): [`../strategy/roadmap.md`](../strategy/roadmap.md)


### PR DESCRIPTION
## Summary

Updates ADR-006 to reflect the B-50a.2 decision (made 2026-05-08): collapse the 4-tier OCR stack to 3-tier by retiring \`chandra-local\` Tier 1a in favor of \`typhoon-ocr-local\` Tier 1c for handwriting.

## Why

When the original ADR-006 was written, chandra was assumed to be a lightweight (~80MB) EasyOCR-class engine. When \`chandra-ocr\` v0.2.0 actually shipped, it turned out to be a 10.6 GB VLM — same weight class as Tier 1c Typhoon-OCR.

Bench in B-50a.2 (5 synthetic Thai handwritten clinical notes):

| Engine | CER median | Latency median |
|---|---|---|
| chandra-local (EasyOCR-paragraph 1.7.2) | 0.193 | 8.2 s |
| typhoon-ocr-local (1.5-3B via Ollama)   | **0.000** | **2.9 s** |

Typhoon dominates. Two adjacent VLMs at Tier 1a + Tier 1c doing similar work was redundant — collapse keeps only the better one.

## Changes

- **Status:** Accepted → Accepted (revised 2026-05-08 per B-50a.2)
- **Revision summary** block added at top with bench table + link to assessment
- **Tier table:** 4-tier → 3-tier (1b PaddleOCR + 1c Typhoon + cloud Flash/Pro). Note that the legacy \`1a\` slot is retired and not reissued (preserves audit continuity).
- **Smart router rules:** rule 3 now routes \`doc_type=handwriting\` → 1c Typhoon (was 1a chandra); default fallback 1b → 1c (was 1a → 1b)
- **Option E:** marked superseded by new Option F
- **Option F (CHOSEN):** new 3-tier rationale
- **Consequences:** updated to reflect one fewer local service + single-handwriting-engine risk + mitigation
- **References:** added Typhoon-OCR + B-50a.2 assessment; flagged chandra as retired

## Follow-up PRs in other repos

This PR is the canonical decision update. Mechanical follow-ups:

- [ ] **Syn:** drop \`deploy/k8s/chandra-sidecar.yaml\` + \`services/chandra-sidecar/\`; update README / ARCHITECTURE / ROADMAP / smart-router README to 3-tier
- [ ] **Syn-Sidecars:** drop \`services/chandra-sidecar/\` + remove from CI matrix
- [ ] **Mimir:** update \`docs/03_implementation_plans/03_14_Local_LLM_Optimization_Sprints.md\` Sprint 50 backlog to mark B-50a.2 done

## Test plan

- [ ] Markdown renders cleanly
- [ ] Cross-link to B-50a.2 assessment doc resolves (Syn repo, currently private — fine, link will work once Syn flips public)
- [ ] Cross-link to Mimir Sprint 50 plan resolves
- [ ] Reviewers confirm tier numbering note (1a retired, 1b/1c keep numbers) preserves audit-log continuity

🤖 Generated with [Claude Code](https://claude.com/claude-code)