### PR TITLE
feat(b-50j): E2E runbook + script for lab report → ICD-10 path

### DIFF
--- a/docs/technical/e2e-ocr-lab-icd10.md
+++ b/docs/technical/e2e-ocr-lab-icd10.md
@@ -1,0 +1,95 @@
+# E2E — Lab Report Image → Eir → ICD-10
+
+**Sprint 50 B-50j operational verification.**
+
+Validates the full Phase A path lands: clinician uploads a lab report image, Eir extracts the diagnoses, calls Hermodr's `icd10_lookup` for code mapping, and returns ICD-10 codes grounded in the document. This isn't a unit test — it spans Mimir, Bifrost, Syn, Hermodr, Heimdall, plus the deployed MariaDB. Run it as a smoke test after deploying the Sprint 50 stack to OrbStack / staging.
+
+## Prerequisites
+
+- Asgard stack up on OrbStack K8s:
+  - `mimir-api`, `bifrost`, `syn-api` (+ PaddleOCR sidecar, Typhoon-OCR via Ollama), `heimdall-gateway`, `hermodr`
+  - MariaDB seeded with sprint38 Eir specialists + sprint50 OCR foundation + B-50g allowlist migration
+- A test lab report image (any Thai/English clinical report; the smaller the better — keep under ~2 MB to avoid encoding pain)
+- Tailnet access or `kubectl port-forward` to reach the services (see `Asgard/docs/technical/port-allocation-startup.md`)
+
+## Quick smoke test (shell script)
+
+```bash
+./scripts/e2e_lab_icd10.sh path/to/lab_report.png
+```
+
+The script chains: image → Syn OCR (Tier 1 PaddleOCR by default) → Mimir `/agents/chat` with the extracted text + a "give me ICD-10 codes" prompt → grep response for ICD-10 patterns.
+
+Exit codes:
+
+- `0` — OCR succeeded AND at least one ICD-10-shaped code matched (`[A-Z]\d{2}(\.\d+)?`)
+- `1` — OCR failure (Syn returned engine_failed / 502 / non-2xx)
+- `2` — Agent returned without any ICD-10 code (could be: low-confidence OCR, agent didn't call `icd10_lookup`, or the report had no codeable findings)
+
+Code 2 is the most useful failure mode — it means the wiring works but the AI didn't deliver. Investigate by:
+
+1. Re-running with `-v` flag to dump the raw chat response (look at the `[Attached Document]` block — is the OCR text legible?)
+2. Checking Laminar (Sága) trace at <https://laminar.asgard.internal/projects> — did the agent call `icd10_lookup` at all?
+3. Trying with a different specialty agent (`?persona=eir-cardio` vs `?persona=eir-internal-medicine` once renamed) — sometimes specialty framing drives more aggressive code-mapping
+
+## Manual variant (curl)
+
+If you want to inspect each stage:
+
+```bash
+# 1) Encode image
+BASE64=$(base64 -i lab_report.png | tr -d '\n')
+
+# 2) OCR via Syn (smart router picks engine)
+curl -s -X POST https://syn.asgard.internal/api/v1/syn/ocr/extract-json \
+  -H "X-Tenant-Id: asgard_medical" \
+  -H "Content-Type: application/json" \
+  -d "{\"image_base64\":\"$BASE64\",\"filename\":\"lab.png\"}" | tee /tmp/ocr.json
+# Expect: { audit_id, engine_used, status: "succeeded", extracted_text, cost_usd, latency_ms, ... }
+
+# 3) Pull extracted text
+TEXT=$(jq -r '.extracted_text' /tmp/ocr.json)
+AUDIT=$(jq -r '.audit_id' /tmp/ocr.json)
+ENGINE=$(jq -r '.engine_used' /tmp/ocr.json)
+
+# 4) Ask Eir for ICD-10 codes — message body uses the same marker
+# format the B-50i dashboard uses, so the agent treats document text and
+# query separately.
+PROMPT="[Attached Document — extracted via ${ENGINE} (audit_id=${AUDIT})]
+${TEXT}
+[End of document]
+
+Identify all clinical findings in this lab report and return matching ICD-10-CM codes. Use the icd10_lookup tool. Output as a markdown table with columns: finding | code | description."
+
+curl -s -X POST https://mimir.asgard.internal/api/v1/agents/chat \
+  -H "X-Tenant-Id: asgard_medical" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg msg "$PROMPT" '{tier: 2, message: $msg, persona: "eir"}')"
+```
+
+Look for `[A-Z][0-9]{2}(\.[0-9]+)?` patterns in `content`.
+
+## Acceptance criteria (sprint plan)
+
+> B-50j — End-to-end test: lab report image → Eir-medtech → ICD-10 codes (chains B-48h FHIR)
+
+Practical interpretation, given the actual agent roster:
+
+- [ ] Image → `extracted_text` returned by Syn (any engine) — verifies B-50a/c/e
+- [ ] Agent response contains ≥1 ICD-10-shaped code — verifies B-50g (allowlist) + Hermodr `icd10_lookup` + B-48h ICD-10 backend
+- [ ] Laminar shows the span tree: Bifrost → Mimir → Syn → engine, then Bifrost → Heimdall → Eir → Hermodr `icd10_lookup` calls
+- [ ] If `cloud_flash_enabled=true` and budget headroom: cost_usd > 0 visible on dashboard `/analytics/llm` Recent OCR Calls table (post-#268)
+
+## What this test does NOT cover
+
+- **Accuracy of OCR or coding.** This verifies the wire — not that codes match the clinician's expert read. CER and code-precision live in B-50h (clinician-curated test set) which is gated on partner data.
+- **Multi-page PDFs.** Out of scope for Sprint 50 (deferred).
+- **PHI strict path.** That's its own verification — enable `ocr_phi_strict` for a test tenant and confirm the Bifrost transparent path returns 403 (see B-50d Bifrost #13).
+- **Budget exceeded path.** Set a small `ocr_monthly_cloud_budget_usd` and run repeatedly until 402 (see B-50m Mimir #266).
+
+## Companion artifacts
+
+- **Image:** `tests/fixtures/lab_report_sample.png` (anonymized; if absent, supply your own)
+- **Script:** `scripts/e2e_lab_icd10.sh`
+- **Laminar dashboard:** <https://laminar.asgard.internal/projects>
+- **OCR Cost Guard dashboard:** <https://mimir.asgard.internal/analytics/llm> → OCR tab (post-#267)

--- a/scripts/e2e/lab_icd10.sh
+++ b/scripts/e2e/lab_icd10.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════
+# 🩺 Sprint 50 B-50j — E2E: Lab Report Image → Eir → ICD-10
+# Chains: Syn OCR → Mimir agent chat → Hermodr icd10_lookup
+# ═══════════════════════════════════════════════════════════════
+#
+# Usage:
+#   ./scripts/e2e/lab_icd10.sh path/to/lab.png [--verbose] [--persona eir-cardio]
+#
+# Exit codes:
+#   0 — OCR succeeded AND ≥1 ICD-10-shaped code in response
+#   1 — OCR failed or transport error
+#   2 — Agent responded but produced no ICD-10 code
+#
+# Env overrides:
+#   SYN_URL         (default: https://syn.asgard.internal)
+#   MIMIR_URL       (default: https://mimir.asgard.internal)
+#   TENANT_ID       (default: asgard_medical)
+#   PERSONA         (default: eir)
+
+set -euo pipefail
+
+SYN_URL="${SYN_URL:-https://syn.asgard.internal}"
+MIMIR_URL="${MIMIR_URL:-https://mimir.asgard.internal}"
+TENANT_ID="${TENANT_ID:-asgard_medical}"
+PERSONA="${PERSONA:-eir}"
+VERBOSE=0
+
+# ─── arg parse ───────────────────────────────────────────────────
+IMG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v|--verbose) VERBOSE=1; shift ;;
+    --persona) PERSONA="$2"; shift 2 ;;
+    --tenant) TENANT_ID="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '4,20p' "$0"
+      exit 0 ;;
+    *) IMG="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$IMG" || ! -f "$IMG" ]]; then
+  echo "❌ usage: $0 path/to/lab_report.png [--verbose] [--persona name]"
+  exit 1
+fi
+
+log()  { echo "  $*" >&2; }
+warn() { echo "⚠️  $*" >&2; }
+fail() { echo "❌ $*" >&2; exit "${2:-1}"; }
+ok()   { echo "✅ $*" >&2; }
+
+# ─── 1) Encode image ──────────────────────────────────────────────
+log "Encoding $IMG ..."
+BASE64=$(base64 -i "$IMG" 2>/dev/null | tr -d '\n')
+[[ -z "$BASE64" ]] && fail "base64 encode failed"
+
+# ─── 2) Call Syn OCR ──────────────────────────────────────────────
+log "POST $SYN_URL/api/v1/syn/ocr/extract-json (tenant=$TENANT_ID)"
+OCR_REQ=$(jq -n --arg b "$BASE64" --arg f "$(basename "$IMG")" \
+  '{image_base64: $b, filename: $f}')
+
+OCR_RESP=$(curl -sS -X POST "$SYN_URL/api/v1/syn/ocr/extract-json" \
+  -H "X-Tenant-Id: $TENANT_ID" \
+  -H "Content-Type: application/json" \
+  --data "$OCR_REQ" \
+  -w '\n%{http_code}')
+
+HTTP=$(echo "$OCR_RESP" | tail -n1)
+BODY=$(echo "$OCR_RESP" | sed '$d')
+
+if [[ "$HTTP" != "200" ]]; then
+  echo "$BODY" >&2
+  fail "Syn OCR returned HTTP $HTTP" 1
+fi
+
+STATUS=$(echo "$BODY" | jq -r '.status // "unknown"')
+if [[ "$STATUS" != "succeeded" ]]; then
+  echo "$BODY" >&2
+  fail "Syn OCR status=$STATUS (expected succeeded)" 1
+fi
+
+ENGINE=$(echo "$BODY"  | jq -r '.engine_used // "?"')
+AUDIT=$(echo "$BODY"   | jq -r '.audit_id // ""')
+COST=$(echo "$BODY"    | jq -r '.cost_usd // 0')
+LAT=$(echo "$BODY"     | jq -r '.latency_ms // 0')
+TEXT=$(echo "$BODY"    | jq -r '.extracted_text // ""')
+TEXTLEN=${#TEXT}
+
+ok "OCR succeeded — engine=$ENGINE audit=$AUDIT cost_usd=$COST latency=${LAT}ms text_len=$TEXTLEN"
+
+if [[ "$TEXTLEN" -lt 20 ]]; then
+  warn "Extracted text is very short ($TEXTLEN chars) — agent unlikely to find ICD codes"
+fi
+
+if [[ "$VERBOSE" -eq 1 ]]; then
+  log "─── extracted text ───"
+  echo "$TEXT" | sed 's/^/    /' >&2
+  log "──────────────────────"
+fi
+
+# ─── 3) Call Mimir agent chat ─────────────────────────────────────
+PROMPT="[Attached Document — extracted via ${ENGINE} (audit_id=${AUDIT})]
+${TEXT}
+[End of document]
+
+Identify all clinical findings in this lab report and return matching ICD-10-CM codes. Use the icd10_lookup tool if you have it. Output as a markdown table with columns: finding | code | description."
+
+log "POST $MIMIR_URL/api/v1/agents/chat (persona=$PERSONA)"
+CHAT_REQ=$(jq -n --arg msg "$PROMPT" --arg p "$PERSONA" \
+  '{tier: 2, message: $msg, persona: $p}')
+
+CHAT_RESP=$(curl -sS -X POST "$MIMIR_URL/api/v1/agents/chat" \
+  -H "X-Tenant-Id: $TENANT_ID" \
+  -H "Content-Type: application/json" \
+  --data "$CHAT_REQ" \
+  -w '\n%{http_code}')
+
+HTTP=$(echo "$CHAT_RESP" | tail -n1)
+BODY=$(echo "$CHAT_RESP" | sed '$d')
+
+if [[ "$HTTP" != "200" ]]; then
+  echo "$BODY" >&2
+  fail "Mimir agent chat returned HTTP $HTTP" 1
+fi
+
+CONTENT=$(echo "$BODY" | jq -r '.content // ""')
+[[ -z "$CONTENT" ]] && fail "agent response had no content" 1
+
+if [[ "$VERBOSE" -eq 1 ]]; then
+  log "─── agent response ───"
+  echo "$CONTENT" | sed 's/^/    /' >&2
+  log "──────────────────────"
+fi
+
+# ─── 4) Verify ICD-10 codes present ──────────────────────────────
+CODES=$(echo "$CONTENT" | grep -oE '\b[A-TV-Z][0-9]{2}(\.[0-9A-Z]{1,4})?\b' | sort -u || true)
+
+if [[ -z "$CODES" ]]; then
+  warn "No ICD-10-shaped codes found in response"
+  warn "  (engine=$ENGINE, persona=$PERSONA, text_len=$TEXTLEN)"
+  warn "  Re-run with --verbose to inspect the OCR text + agent output"
+  exit 2
+fi
+
+CODE_COUNT=$(echo "$CODES" | wc -l | tr -d ' ')
+ok "Found $CODE_COUNT ICD-10 code(s): $(echo "$CODES" | tr '\n' ' ')"
+exit 0


### PR DESCRIPTION
## Summary

Sprint 50 B-50j — operational verification of the full Phase A path: lab report image → Syn OCR → Eir agent chat → Hermodr \`icd10_lookup\` → response with ICD-10 codes.

**Not a unit test.** This spans Mimir + Bifrost + Syn + Hermodr + Heimdall + MariaDB and is meant to run against a deployed Asgard stack (OrbStack / staging) as a smoke test after the Sprint 50 stack lands.

## What ships

- \`docs/technical/e2e-ocr-lab-icd10.md\` — runbook with:
  - Prerequisites (deployed stack + seeded DB + B-50g allowlist migration)
  - Quick smoke-test (one-liner shell script)
  - Manual variant (curl-by-curl breakdown for debugging)
  - Sprint plan acceptance criteria reinterpreted for the actual agent roster (\`eir\` + 4 specialty clones, not the plan's stale \`eir-medtech\`/\`pharmacy\`/\`internal-medicine\`)
  - Explicit list of what this test does NOT cover (accuracy, multi-page PDFs, PHI-strict + budget-exceeded paths — those have their own verifications)
- \`scripts/e2e/lab_icd10.sh\` — bash script chaining Syn OCR → Mimir agent chat → grep for ICD-10-shaped codes (\`[A-TV-Z][0-9]{2}(\\.[0-9A-Z]{1,4})?\`)

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | OCR succeeded AND ≥1 ICD-10-shaped code in response |
| 1 | Transport failure or Syn OCR returned engine_failed / non-2xx |
| 2 | Wired correctly but agent didn't produce ICD-10 codes — **the most useful failure mode** (re-run with \`--verbose\` to inspect OCR text + agent response; check Laminar trace for whether icd10_lookup was called) |

## Companion PRs

- **Mimir #265** — Syn smart-router delegation
- **Mimir #269** — B-50g \`ocr_extract\` in Eir tool allowlists
- **Bifrost #13** — B-50d transparent OCR (alternative path; script uses the simpler chained-curl flow)
- **Mimir #270** — B-50i dashboard upload (manual equivalent for non-script users)

## Test plan

- [ ] After all companion PRs merge + Sprint 50 stack deploys: run \`./scripts/e2e/lab_icd10.sh <test_image.png>\` and verify exit 0
- [ ] Verify Laminar trace shows Bifrost → Mimir → Syn span tree, then Bifrost → Heimdall → Hermodr icd10_lookup
- [ ] Re-run after rotating PaddleOCR sidecar — verify no regression
- [ ] Run with \`--persona eir-cardio\` on a cardiac report and \`--persona eir-pediatrics\` on a peds report — verify specialty framing improves code precision

🤖 Generated with [Claude Code](https://claude.com/claude-code)