### PR TITLE
fix(ci): pass all 7 required Helm secrets to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,31 @@ jobs:
         run: helm dependency update ${{ env.CHART_PATH }}
 
       - name: Deploy with Helm
+        # Required GitHub repo secrets (chart `secrets.yaml` template enforces
+        # via `required` — empty values fail the template with a clear message):
+        #   YGGDRASIL_MASTERKEY            ZITADEL masterkey (rotating invalidates sessions)
+        #   YGGDRASIL_POSTGRES_PASSWORD    Zitadel's Postgres user password
+        #   YGGDRASIL_CLIENT_ID            OIDC client id registered in Zitadel
+        #   YGGDRASIL_CLIENT_SECRET        OIDC client secret (regen in Zitadel admin UI)
+        #   MARIADB_ROOT_PASSWORD          MariaDB root password
+        #   MARIADB_PASSWORD               mimir DB user password
+        #   NEO4J_PASSWORD                 Mimir RAG breaks silently if empty
+        #   HEIMDALL_API_KEY               Bifrost cannot call Heimdall without it
+        # Optional (have safe defaults in chart):
+        #   JWT_SECRET, GEMINI_API_KEY
         run: |
           helm upgrade --install asgard ${{ env.CHART_PATH }} \
             --namespace ${{ steps.env.outputs.namespace }} \
             --create-namespace \
             -f ${{ env.CHART_PATH }}/values.yaml \
             -f ${{ env.CHART_PATH }}/${{ steps.env.outputs.values_file }} \
+            --set secrets.yggdrasil.masterKey="${{ secrets.YGGDRASIL_MASTERKEY }}" \
+            --set secrets.yggdrasil.postgresPassword="${{ secrets.YGGDRASIL_POSTGRES_PASSWORD }}" \
+            --set secrets.yggdrasil.clientId="${{ secrets.YGGDRASIL_CLIENT_ID }}" \
+            --set secrets.yggdrasil.clientSecret="${{ secrets.YGGDRASIL_CLIENT_SECRET }}" \
+            --set secrets.mariadb.rootPassword="${{ secrets.MARIADB_ROOT_PASSWORD }}" \
+            --set secrets.mariadb.password="${{ secrets.MARIADB_PASSWORD }}" \
+            --set secrets.neo4j.password="${{ secrets.NEO4J_PASSWORD }}" \
             --set secrets.heimdallApiKey="${{ secrets.HEIMDALL_API_KEY }}" \
             --set secrets.jwtSecret="${{ secrets.JWT_SECRET }}" \
             --set secrets.geminiApiKey="${{ secrets.GEMINI_API_KEY }}" \


### PR DESCRIPTION
**Fixes deploy failure** — https://github.com/MegaWiz-Dev-Team/Asgard/actions/runs/25704789591

```
Error: UPGRADE FAILED: execution error at (asgard/templates/secrets.yaml:31:26):
  secrets.yggdrasil.masterKey is required
```

The chart's templates/secrets.yaml now enforces 8 secrets via Helm's `required` function (Sprint 51e rotation hardening). The workflow only passed 3, so the template failed render before any pod was scheduled.

## What this PR changes

Workflow now passes all 7 required + 2 optional secrets from GitHub repo secrets:

| Secret | Required? | Purpose |
|---|---|---|
| `YGGDRASIL_MASTERKEY` | ✅ | Zitadel masterkey (rotating invalidates sessions) |
| `YGGDRASIL_POSTGRES_PASSWORD` | ✅ | Zitadel's Postgres user password |
| `YGGDRASIL_CLIENT_ID` | ✅ | OIDC client id registered in Zitadel |
| `YGGDRASIL_CLIENT_SECRET` | ✅ | OIDC client secret (regen in Zitadel admin UI) |
| `MARIADB_ROOT_PASSWORD` | ✅ | MariaDB root password |
| `MARIADB_PASSWORD` | ✅ | mimir DB user password |
| `NEO4J_PASSWORD` | ✅ | **Mimir RAG breaks silently if empty** |
| `HEIMDALL_API_KEY` | ✅ | Bifrost cannot call Heimdall without it (already passed) |
| `JWT_SECRET` | optional | (already passed) |
| `GEMINI_API_KEY` | optional | (already passed) |

## ⚠ Action required after merge

The 7 new secrets must be populated in **GitHub repo settings → Secrets and variables → Actions**. Sprint 51e memory shows 5/7 rotations done (Heimdall/Neo4j/MariaDB/Postgres/Mimir-OIDC) — those values exist somewhere in Vault. `YGGDRASIL_MASTERKEY` itself is Sprint 51e Step 8 which was deferred — if it hasn't been rotated yet, pull the current production masterkey from K8s:

```bash
kubectl -n asgard get secret asgard-secrets -o jsonpath='{.data.YGGDRASIL_MASTERKEY}' | base64 -d
```

If any secret is empty the template rejects the install (intended fail-loud).