### PR TITLE
fix(ci): strip stale kubectl field-managers + --force Helm upgrade

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,11 +94,42 @@ jobs:
             exit 1
           fi
 
+      - name: Strip conflicting kubectl field-managers
+        # Sprint 51e applied several `kubectl patch` operations directly to
+        # live resources (Bifrost DATABASE_URL → secretKeyRef migration,
+        # Mimir-API client ID rotation, etc.). Those leave a `kubectl` /
+        # `kubectl-patch` field-manager that conflicts with Helm's SSA
+        # ownership on the next `helm upgrade`. Strip the foreign managers
+        # so Helm's reapply lands cleanly.
+        #
+        # We don't blow away resources — just remove the managedFields
+        # subresource. The actual data in each resource is preserved; the
+        # next Helm apply re-claims ownership of the same field values.
+        run: |
+          NS="${{ steps.env.outputs.namespace }}"
+          # Resources flagged by the previous Helm conflict (extend the
+          # list if other resources have been hand-patched). Failures here
+          # are non-fatal: kubectl patch returns 0 if there's nothing to
+          # strip.
+          for r in deploy/bifrost configmap/otel-collector-config; do
+            if kubectl -n "$NS" get "$r" >/dev/null 2>&1; then
+              echo "Stripping managedFields on $NS/$r"
+              kubectl -n "$NS" patch "$r" --type=json \
+                -p='[{"op":"remove","path":"/metadata/managedFields"}]' >/dev/null 2>&1 || true
+            fi
+          done
+
       - name: Deploy with Helm
         # `--set secrets.create=false` tells the chart NOT to render
         # templates/secrets.yaml. Subcharts only consume via secretKeyRef
-        # pointing at the operator-created asgard-secrets. No value
-        # plumbing through `--set` needed — secrets stay in K8s.
+        # pointing at the operator-created asgard-secrets.
+        #
+        # `--force` permits resource recreate on irreconcilable conflict —
+        # safe for dev clusters; Sprint 51e hand-patches that landed in
+        # the chart proper get superseded by the canonical chart state.
+        # Combined with the `Strip conflicting kubectl field-managers`
+        # step above, hand-patches that AREN'T in the chart yet are
+        # silently lost (intended behaviour — chart is source of truth).
         run: |
           helm upgrade --install asgard ${{ env.CHART_PATH }} \
             --namespace ${{ steps.env.outputs.namespace }} \
@@ -106,6 +137,7 @@ jobs:
             -f ${{ env.CHART_PATH }}/values.yaml \
             -f ${{ env.CHART_PATH }}/${{ steps.env.outputs.values_file }} \
             --set secrets.create=false \
+            --force \
             --wait --timeout 5m
 
       - name: Verify deployment


### PR DESCRIPTION
Fourth deploy failure — Helm SSA refused to apply because Bifrost + otel-collector-config had a 'kubectl-patch' field-manager from Sprint 51e hand-patches.

Pre-step strips `/metadata/managedFields` only (field values intact). Then `helm upgrade --force` claims ownership cleanly.

Trade-off documented inline: hand-patches not in the chart yet get superseded by the canonical chart state. Chart is GitOps source of truth.