### PR TITLE
fix(bifrost): wire DATABASE_URL from asgard-secrets

### DIFF
--- a/charts/asgard/charts/bifrost/templates/deployment.yaml
+++ b/charts/asgard/charts/bifrost/templates/deployment.yaml
@@ -23,6 +23,18 @@ spec:
           env:
             - { name: BIFROST_HOST, value: "0.0.0.0" }
             - { name: BIFROST_PORT, value: "8100" }
+            # Bifrost's main.rs panics on missing DATABASE_URL. Sourced
+            # from the shared asgard-secrets so the Sprint 51e mariadb
+            # rotation flows here automatically. MIMIR_DATABASE_URL
+            # carries the full `mysql://user:pass@host:port/db` string.
+            # Sprint 51e hand-patched this onto the running deployment;
+            # this template makes it permanent so `helm upgrade` doesn't
+            # lose it on recreate.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.secretsName | default "asgard-secrets" }}
+                  key: MIMIR_DATABASE_URL
             - { name: HEIMDALL_URL, value: {{ .Values.global.heimdallUrl | quote }} }
             - name: HEIMDALL_API_KEY
               valueFrom:


### PR DESCRIPTION
Bifrost panics on startup without DATABASE_URL. Sprint 51e hand-patched the running deploy; the chart template was missing it, so when the deploy workflow recreated Bifrost the env var was lost → CrashLoopBackOff. This makes the wire permanent in the chart.