### PR TITLE
fix(ci): Bifrost integ-test uses cargo test (Rust rewrite)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,9 +17,6 @@ on:
   workflow_dispatch:
 
 env:
-  # actions/setup-python defaults to /Users/runner/hostedtoolcache; the runner
-  # is user `mimir`, so we redirect the toolcache into the runner workspace.
-  AGENT_TOOLSDIRECTORY: /Users/mimir/Developer/actions-runner/_work/_tool
   ASGARD_DEV_ROOT: /Users/mimir/Developer
   FORSETI_URL: http://localhost:30555
 
@@ -31,13 +28,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+      - name: Resolve Python interpreters
+        id: py
+        # actions/setup-python@v5 hardcodes /Users/runner/hostedtoolcache on
+        # macOS and ignores AGENT_TOOLSDIRECTORY — broken on this self-hosted
+        # runner (user is `mimir`). Each sibling repo manages its own .venv,
+        # so we just verify they exist and surface paths for later steps.
+        run: |
+          FORSETI_PY="${ASGARD_DEV_ROOT}/Forseti/.venv/bin/python"
+          BIFROST_PY="${ASGARD_DEV_ROOT}/Bifrost/.venv/bin/python"
+          SYSTEM_PY=$(command -v python3.11 || command -v python3)
 
-      - name: Install test dependencies
-        run: pip install httpx pytest pytest-asyncio
+          for v in "$FORSETI_PY" "$BIFROST_PY"; do
+            if [ ! -x "$v" ]; then
+              echo "::error::missing venv interpreter: $v — bootstrap with 'python3 -m venv .venv && .venv/bin/pip install -r requirements.txt'"
+              exit 1
+            fi
+          done
+          echo "forseti_py=$FORSETI_PY" >> "$GITHUB_OUTPUT"
+          echo "bifrost_py=$BIFROST_PY" >> "$GITHUB_OUTPUT"
+          echo "system_py=$SYSTEM_PY" >> "$GITHUB_OUTPUT"
+
+          echo "Forseti  $($FORSETI_PY --version)"
+          echo "Bifrost  $($BIFROST_PY --version)"
+          echo "System   $($SYSTEM_PY --version 2>/dev/null || echo missing)"
 
       - name: Wait for services
         run: |
@@ -65,7 +79,7 @@ jobs:
           set -o pipefail
           cd "$FORSETI_REPO"
           # run_e2e.py auto-posts each project's run into Forseti's own DB.
-          python run_e2e.py --project bifrost-api
+          "${{ steps.py.outputs.forseti_py }}" run_e2e.py --project bifrost-api
 
       - name: Run Bifrost pytest
         id: bifrost_pytest
@@ -79,7 +93,7 @@ jobs:
           # Always export the junit path so the push step can ingest results even on failure.
           echo "junit=$JUNIT" >> "$GITHUB_OUTPUT"
           set +e
-          .venv/bin/python -m pytest tests/ -v --tb=short --junitxml="$JUNIT"
+          "${{ steps.py.outputs.bifrost_py }}" -m pytest tests/ -v --tb=short --junitxml="$JUNIT"
           PYTEST_EXIT=$?
           echo "exit_code=$PYTEST_EXIT" >> "$GITHUB_OUTPUT"
           exit $PYTEST_EXIT
@@ -89,7 +103,7 @@ jobs:
         env:
           FORSETI_REPO: ${{ env.ASGARD_DEV_ROOT }}/Forseti
         run: |
-          python "$FORSETI_REPO/scripts/junit_to_forseti.py" \
+          "${{ steps.py.outputs.forseti_py }}" "$FORSETI_REPO/scripts/junit_to_forseti.py" \
             --junit "${{ steps.bifrost_pytest.outputs.junit }}" \
             --suite bifrost-pytest \
             --phase SIT \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -81,22 +81,49 @@ jobs:
           # run_e2e.py auto-posts each project's run into Forseti's own DB.
           "${{ steps.py.outputs.forseti_py }}" run_e2e.py --project bifrost-api
 
-      - name: Run Bifrost pytest
+      - name: Run Bifrost cargo test
         id: bifrost_pytest
         continue-on-error: true
         env:
           BIFROST_REPO: ${{ env.ASGARD_DEV_ROOT }}/Bifrost
+        # Bifrost was Python until Sprint 38; the rewrite is now Rust
+        # (`Cargo.toml` v0.3.0+). The old `pytest tests/` step failed
+        # with ModuleNotFoundError since the tests imported from
+        # `bifrost.X` Python packages that no longer exist (deleted in
+        # Bifrost #15). Run `cargo test` instead; emit a stub junit so
+        # the downstream Forseti push step keeps working.
+        #
+        # Step name + output id kept as `bifrost_pytest` for back-compat
+        # with the Forseti ingest scripts.
         run: |
           cd "$BIFROST_REPO"
           mkdir -p .test-results
           JUNIT="$BIFROST_REPO/.test-results/bifrost-pytest.xml"
-          # Always export the junit path so the push step can ingest results even on failure.
           echo "junit=$JUNIT" >> "$GITHUB_OUTPUT"
           set +e
-          "${{ steps.py.outputs.bifrost_py }}" -m pytest tests/ -v --tb=short --junitxml="$JUNIT"
-          PYTEST_EXIT=$?
-          echo "exit_code=$PYTEST_EXIT" >> "$GITHUB_OUTPUT"
-          exit $PYTEST_EXIT
+          # cargo test produces TAP, not junit. Use cargo2junit if
+          # available; otherwise fall back to a minimal junit stub
+          # carrying the pass/fail outcome so Forseti still gets a row.
+          if command -v cargo2junit >/dev/null 2>&1; then
+            cargo test --release --no-fail-fast -- -Z unstable-options --format json 2>&1 \
+              | cargo2junit > "$JUNIT" || true
+            EXIT=${PIPESTATUS[0]}
+          else
+            cargo test --release --no-fail-fast 2>&1 | tee /tmp/bifrost-cargo-test.log
+            EXIT=${PIPESTATUS[0]}
+            # Synthesize a single-row junit so the push step works
+            STATUS=$([ "$EXIT" = "0" ] && echo "" || echo '<failure message="cargo test exit $EXIT"/>')
+            cat > "$JUNIT" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="bifrost-cargo-test" tests="1" failures="$([ "$EXIT" = "0" ] && echo 0 || echo 1)">
+    <testcase classname="bifrost" name="cargo_test">$STATUS</testcase>
+  </testsuite>
+</testsuites>
+EOF
+          fi
+          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+          exit $EXIT
 
       - name: Push Bifrost pytest results to Forseti
         if: always() && steps.forseti_up.outputs.available == 'true' && steps.bifrost_pytest.outputs.junit != ''


### PR DESCRIPTION
Bifrost is Rust now; pytest collection fails with ModuleNotFoundError. Replace with cargo test + synthesize junit XML so Forseti ingest stays working.