### PR TITLE
fix(ci): heredoc inside run-block scalar broke YAML — use echo lines instead

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -111,16 +111,24 @@ jobs:
           else
             cargo test --release --no-fail-fast 2>&1 | tee /tmp/bifrost-cargo-test.log
             EXIT=${PIPESTATUS[0]}
-            # Synthesize a single-row junit so the push step works
-            STATUS=$([ "$EXIT" = "0" ] && echo "" || echo '<failure message="cargo test exit $EXIT"/>')
-            cat > "$JUNIT" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
-  <testsuite name="bifrost-cargo-test" tests="1" failures="$([ "$EXIT" = "0" ] && echo 0 || echo 1)">
-    <testcase classname="bifrost" name="cargo_test">$STATUS</testcase>
-  </testsuite>
-</testsuites>
-EOF
+            # Synthesize a single-row junit so the push step works.
+            # Avoid YAML-breaking heredoc: build the XML with echo lines
+            # so every line stays inside the `run: |` block scalar's indent.
+            if [ "$EXIT" = "0" ]; then
+              FAILURES=0
+              CASE='<testcase classname="bifrost" name="cargo_test"/>'
+            else
+              FAILURES=1
+              CASE="<testcase classname=\"bifrost\" name=\"cargo_test\"><failure message=\"cargo test exit $EXIT\"/></testcase>"
+            fi
+            {
+              echo '<?xml version="1.0" encoding="UTF-8"?>'
+              echo '<testsuites>'
+              echo "  <testsuite name=\"bifrost-cargo-test\" tests=\"1\" failures=\"$FAILURES\">"
+              echo "    $CASE"
+              echo '  </testsuite>'
+              echo '</testsuites>'
+            } > "$JUNIT"
           fi
           echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
           exit $EXIT


### PR DESCRIPTION
## Summary
Commit [`ad81d69`](https://github.com/MegaWiz-Dev-Team/Asgard/commit/ad81d69) (Bifrost cargo test) embedded a `cat <<EOF` heredoc inside a `run: |` block. The heredoc body at column 1 terminated the YAML block scalar early — `<?xml` became a top-level YAML key and GitHub rejected the workflow with "workflow file issue."

**Impact:** every Integration Tests run on main since `ad81d69` failed before any step executed. See [run 25714385435](https://github.com/MegaWiz-Dev-Team/Asgard/actions/runs/25714385435).

## Fix
Replace heredoc with `{ echo …; }` redirect — every byte stays within the bash step's indentation, YAML stays well-formed, no functional change.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` passes
- [x] Locally simulated EXIT=0 and EXIT=1 — junit shape parses cleanly through `Forseti/scripts/junit_to_forseti.py --dry-run`
- [ ] Post-merge: `workflow_dispatch` Integration Tests to confirm the workflow loads + steps run

🤖 Generated with [Claude Code](https://claude.com/claude-code)