### PR TITLE
test(ci): wire Syn into Asgard integration-test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -81,6 +81,34 @@ jobs:
           # run_e2e.py auto-posts each project's run into Forseti's own DB.
           "${{ steps.py.outputs.forseti_py }}" run_e2e.py --project bifrost-api
 
+      - name: Run Forseti YAML scenarios (syn-api)
+        id: forseti_scenarios_syn
+        continue-on-error: true
+        env:
+          FORSETI_REPO: ${{ env.ASGARD_DEV_ROOT }}/Forseti
+        # Sprint 50 — Syn S1 smoke tests (10 scenarios, mostly GET).
+        # Advisory until Sprint 50 SQL migrations land on the live cluster
+        # — the /policy + /documents routes currently 500 without the
+        # ocr_documents table + tenant_configs Sprint 50 columns.
+        run: |
+          set -o pipefail
+          cd "$FORSETI_REPO"
+          "${{ steps.py.outputs.forseti_py }}" run_e2e.py --project syn-api
+
+      - name: Run Syn cargo test (syn-api smart router unit tests)
+        id: syn_cargo_test
+        continue-on-error: true
+        env:
+          SYN_REPO: ${{ env.ASGARD_DEV_ROOT }}/Syn
+          # mimir-core-ai isn't a dep here but pin offline for parity with
+          # the Bifrost step — Syn uses sqlx::query! macros directly.
+          SQLX_OFFLINE: "true"
+        run: |
+          set -o pipefail
+          cd "$SYN_REPO/services/api"
+          cargo test --release --no-fail-fast 2>&1 | tee /tmp/syn-cargo-test.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
       - name: Run Bifrost cargo test
         id: bifrost_pytest
         continue-on-error: true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -111,16 +111,24 @@ jobs:
           else
             cargo test --release --no-fail-fast 2>&1 | tee /tmp/bifrost-cargo-test.log
             EXIT=${PIPESTATUS[0]}
-            # Synthesize a single-row junit so the push step works
-            STATUS=$([ "$EXIT" = "0" ] && echo "" || echo '<failure message="cargo test exit $EXIT"/>')
-            cat > "$JUNIT" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
-  <testsuite name="bifrost-cargo-test" tests="1" failures="$([ "$EXIT" = "0" ] && echo 0 || echo 1)">
-    <testcase classname="bifrost" name="cargo_test">$STATUS</testcase>
-  </testsuite>
-</testsuites>
-EOF
+            # Synthesize a single-row junit so the push step works.
+            # Avoid YAML-breaking heredoc: build the XML with echo lines
+            # so every line stays inside the `run: |` block scalar's indent.
+            if [ "$EXIT" = "0" ]; then
+              FAILURES=0
+              CASE='<testcase classname="bifrost" name="cargo_test"/>'
+            else
+              FAILURES=1
+              CASE="<testcase classname=\"bifrost\" name=\"cargo_test\"><failure message=\"cargo test exit $EXIT\"/></testcase>"
+            fi
+            {
+              echo '<?xml version="1.0" encoding="UTF-8"?>'
+              echo '<testsuites>'
+              echo "  <testsuite name=\"bifrost-cargo-test\" tests=\"1\" failures=\"$FAILURES\">"
+              echo "    $CASE"
+              echo '  </testsuite>'
+              echo '</testsuites>'
+            } > "$JUNIT"
           fi
           echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
           exit $EXIT

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,6 +86,11 @@ jobs:
         continue-on-error: true
         env:
           BIFROST_REPO: ${{ env.ASGARD_DEV_ROOT }}/Bifrost
+          # mimir-core-ai (Mimir path dep) uses sqlx::query! macros that
+          # require either a live DATABASE_URL or pre-computed query metadata
+          # in .sqlx/. Force offline mode so cargo test doesn't try to
+          # connect to a DB during compilation.
+          SQLX_OFFLINE: "true"
         # Bifrost was Python until Sprint 38; the rewrite is now Rust
         # (`Cargo.toml` v0.3.0+). The old `pytest tests/` step failed
         # with ModuleNotFoundError since the tests imported from


### PR DESCRIPTION
## Summary
- New step: \`Run Forseti YAML scenarios (syn-api)\` — 9 HTTP smoke checks
- New step: \`Run Syn cargo test\` — 13 router unit tests
- Both \`continue-on-error: true\` for Sprint 50 (will gate from Sprint 51)

## Dependencies
- MegaWiz-Dev-Team/Syn#9 (unit tests) — needs merge first
- MegaWiz-Dev-Team/Forseti#6 (syn_e2e.yaml) — needs merge first
- Runner's local forseti.yaml needs \`syn-api\` project block (file is gitignored)

## Test plan
- [ ] Manually trigger Integration Tests workflow after Syn + Forseti PRs land