### PR TITLE
fix(deploy): default imagePullPolicy=Always for ghcr images

### DIFF
--- a/charts/asgard/values-dev.yaml
+++ b/charts/asgard/values-dev.yaml
@@ -11,11 +11,18 @@
 #   To skip per-key flags, drop a values-dev-secrets.yaml (gitignored)
 #   alongside this file with all the `required` values populated.
 global:
-  imagePullPolicy: IfNotPresent  # pull from ghcr.io if not present locally
+  # Always pull on rollout — `:latest` tag silently gets stuck on stale
+  # local images otherwise (saw this 2026-05-12 when Deploy reused a
+  # 5-day-old mimir-api despite a fresh ghcr push). ghcr-secret handles
+  # auth so the extra pull is cheap.
+  imagePullPolicy: Always
   imagePullSecret: ghcr-secret   # private ghcr.io packages — secret pre-created in asgard ns
   infraNamespace: asgard-infra
   heimdallUrl: http://host.docker.internal:8080/v1
   ollamaUrl: http://192.168.1.172:8080
+  # OIDC issuer must match Yggdrasil's ExternalDomain so token `iss` claims and
+  # the browser-visible authorization_endpoint resolve to the public ingress.
+  yggdrasilIssuerUrl: https://sso.asgard.internal
 
 bifrost:
   defaultModel: mlx-community/Qwen3.5-9B-MLX-4bit

--- a/charts/asgard/values.yaml
+++ b/charts/asgard/values.yaml
@@ -10,7 +10,9 @@ global:
   secretsName: asgard-secrets
   # CI-driven image flow: pulls from ghcr.io built by Build-and-Push workflow
   imageRegistry: ghcr.io/megawiz-dev-team
-  imagePullPolicy: IfNotPresent
+  # Always re-pull on rollout — `:latest` is mutable and a cached local
+  # image will silently shadow a fresh ghcr push otherwise.
+  imagePullPolicy: Always
   # Optional: name of pre-existing imagePullSecret if ghcr.io packages are private.
   # Create with: kubectl create secret docker-registry ghcr-secret \
   #   --docker-server=ghcr.io --docker-username=<user> --docker-password=<PAT> -n <ns>


### PR DESCRIPTION
## Summary
- Flip \`global.imagePullPolicy\` from \`IfNotPresent\` to \`Always\` in both \`values.yaml\` and \`values-dev.yaml\`
- Resolves today's regression where Deploy reused a 5-day-old mimir-api image — fresh ghcr push existed but \`IfNotPresent\` + mutable \`:latest\` shadowed it
- Required us to manually \`kubectl patch imagePullPolicy=Always\` + restart on the live cluster to pick up Sprint 50 admin routes

## Why this default
\`:latest\` is mutable. Caching it silently is a footgun. The ghcr-secret pull cost is ~30s for ~150MB cached layers, which is fine for our restart cadence.

## Operator opt-out
Air-gapped or offline-dev clusters can override in a private values file:
\`\`\`yaml
global:
  imagePullPolicy: IfNotPresent
\`\`\`

## Test plan
- [x] Verified live cluster works correctly after manual \`kubectl patch imagePullPolicy=Always\` today (admin/skuggi routes 200, OCR extract 200)
- [ ] Next Deploy workflow run will use the new default