### PR TITLE
docs(architecture): FHIR R4 resource selection (W2.4) + backfill ADRs from this sprint

### DIFF
--- a/docs/architecture/agent_rag_graph_solution_architecture.md
+++ b/docs/architecture/agent_rag_graph_solution_architecture.md
@@ -1,0 +1,570 @@
+# Asgard Solution Architecture — Agent / MCP / RAG / Graph / PageIndex / RefGraph
+
+**Status:** Draft v1
+**Date:** 2026-05-17
+**Scope:** Knowledge & reasoning stack across Asgard Medical + Asgard Insurance deployments
+**Audience:** internal engineering + technical sales
+
+## 1. Problem
+
+Asgard must answer questions and make decisions over heterogeneous documents (scanned charts, policy PDFs, medical certificates, claim forms) using a mix of:
+
+- **Public medical knowledge** (PrimeKG — 129K nodes, 8.1M relations, already imported)
+- **Customer-specific document corpora** (per Mac mini: hospital records / insurance products)
+- **Standardized coding systems** (ICD-10-TM, TMT, TPC, LOINC, SNOMED CT)
+- **Real-time reasoning** from medical/insurance specialists (Eir variants)
+
+The challenge: a single retrieval pattern (chunked vector search) is **insufficient**. We need multiple knowledge representations and retrieval granularities, orchestrated by domain-aware agents — running locally on a single Mac mini per customer with no cross-customer leakage.
+
+## 2. Component Map
+
+| Component | Layer | Role | Status |
+|---|---|---|---|
+| **Syn** | Input | OCR — Thai handwriting champion typhoon-1.5-3b | shipped |
+| **Skuggi** | Input | PII gate — text Tier 1 shipped; image tier W2/W3 pending | partial |
+| **Mimir** | Indexing + Retrieval | RAG service: BGE-M3 embeddings + Qdrant + Neo4j orchestration | shipped (Sprint 48 active) |
+| **Neo4j** | Graph storage | Hosts PrimeKG + RefGraph + SAME_AS links | running in K8s |
+| **Qdrant** | Vector storage | Chunk embeddings + (planned) page-level embeddings | running in K8s |
+| **RefGraph** | Graph derivation | Document → entity extraction → consolidated graph (per deployment) | S1 active (May 19-28 + Jun 2-11) |
+| **PageIndex** | Document navigation | Hierarchical page-level index for long docs (NEW pattern, not yet built) | proposed |
+| **Heimdall** | LLM gateway | Local MLX (gemma-4-26b) + cloud passthrough via Skuggi | shipped |
+| **Bifrost** | Orchestrator | Routes requests to Eir agent variants; enforces tenant boundary | shipped |
+| **Hermodr** | MCP catalog | Tool registry + invocation gateway | shipped |
+| **Eir + variants** | Agent | Domain reasoning — **19 agents designed** (13 specialists + 6 allied health) + eir-router; **5/19 deployed** as Sprint 38 PoC. See [Eir_Agents_Architecture.md](../../../Eir/docs/Eir_Agents_Architecture.md) | partial (5/19 LIVE) |
+| **Tyr** | Audit/SIEM | Per-deployment audit; Wazuh stub during scale-down | scaled-down |
+| **MariaDB/Postgres** | Tabular storage | Cases, audit_events, icd10_codes, chat_sessions | running |
+
+## 2.1 Per-Tenant Component Allocation
+
+Per [ADR-009](../decisions/ADR-009-single-tenant-mac-mini-deployment.md), each Mac mini hosts ONE tenant. All infrastructure components are installed on every box; **agent set + knowledge data + tool catalog differ per tenant**.
+
+### Shared infrastructure (identical on every box)
+
+| Component | Per-tenant variation |
+|---|---|
+| Bifrost | `JWT_AUDIENCE` config per tenant |
+| Heimdall | local MLX; model availability per tenant |
+| Hermodr | tool filter by tenant |
+| Skuggi | global rules |
+| Tyr | LocalDbSink per box |
+| Mimir | collection naming `{tenant}_{collection}` |
+| Syn | global model |
+| Yggdrasil | tenant claim issuance |
+| MariaDB / Qdrant / Neo4j | schemas/collections per tenant |
+
+### `asgard_medical` box (Mega Care + future hospitals)
+
+**Agents** (in `agent_configs` table, all rows with `tenant_id='asgard_medical'`):
+- **19 Eir agents** = 13 medical specialists + 6 allied health (per [Eir_Agents_Architecture.md](../../../Eir/docs/Eir_Agents_Architecture.md))
+- eir-router (Bifrost routing logic)
+- **All agents use LOCAL LLM only** — gemma-4-26b champion, medgemma-27b-text for pediatrics/psychiatry, quantized Q4/Q8 for low-latency emergency/nursing/ent. **NO gemini, NO cloud LLM** (see [feedback_eir_agents_local_only memory](memory))
+- **Eir Gateway (OpenEMR)** — patient/encounter/medication system of record (FHIR R4)
+- Sprint 38 PoC currently has 5/19 deployed; PoC names `eir-cardio` and `eir-sleep` are NOT in target 19 (absorbed into `eir-internal-medicine`); 14 remaining queued for Sprint 43+
+
+**Knowledge data populated:**
+- PrimeKG — full 129K nodes / 8.1M relations in Neo4j ✅ already loaded
+- ICD-10-TM + TMT + TPC in MariaDB ✅ ICD-10-TM anamai 2010 done
+- Clinical guidelines + hospital SOPs + PubMed abstracts subset in Qdrant vector
+- PageIndex on: medical chart bundles, hospital protocols, drug formulary, reference manuals
+
+**RefGraph schema (per-deployment, medical-flavored):**
+```
+(Patient) -[:DIAGNOSED_WITH {date, confidence, source_doc}]-> (Condition) -[:SAME_AS]-> (PrimeKG:Disease)
+(Patient) -[:PRESCRIBED {date, source_doc}]-> (Medication) -[:SAME_AS]-> (PrimeKG:Drug)
+(Patient) -[:UNDERWENT {date, source_doc}]-> (Procedure)
+(Patient) -[:HAS_VISIT]-> (Encounter) -[:CAPTURED_IN]-> (Document)
+```
+
+**Hermodr tool catalog (medical scope, ~35 tools):**
+- `primekg.*` (6) — drug/disease knowledge
+- `refgraph.*` (5) — patient entity graph
+- `pageindex.*` (4) — chart navigation
+- `mimir.search_chunks`
+- `icd10/tmt/tpc.lookup`
+- `clinical_calculator.*` (CHADS2/MELD/eGFR/PHQ-9/GAD-7/Wells/NEXUS/GCS/ASA/Mallampati)
+- `dosage_calculator.*` (pediatric-aware)
+- `drug_interaction_check.*`, `drug_food_interaction`
+- `formulary_lookup`, `patient_education_lookup`, `antibiogram_lookup`, `lab_reference_range`, `community_resource_lookup`
+- `pubmed_search`
+- `read_fhir.*` (Eir Gateway)
+- `syn.extract` (medical chart OCR)
+- `audit.query`
+
+**Workflows (per Eir_Agents_Architecture.md §4):**
+- Outpatient / Surgical / Emergency / Pediatric — full 4 flows
+
+### `asgard_insurance` box (Prudential, ThaiLife, Thai Health)
+
+**Agents** (in `agent_configs` table, all rows with `tenant_id='asgard_insurance'`):
+- **Underwriter consensus agents** (NOT the 19 Eir):
+  - `underwriter-risk-assessor`
+  - `underwriter-medical-analyzer`
+  - `underwriter-fraud-detector`
+  - `underwriter-decision-maker`
+- **Restricted 3-agent Eir subset (READ-ONLY)** for clinical interpretation of applicant history:
+  - `eir-internal-medicine` (read-only tools)
+  - `eir-medtech` (read-only labs)
+  - `eir-pharmacy` (read-only drug knowledge for risk)
+  - These use the same templates as medical but with tool allowlist restricted to read-only knowledge tools — no FHIR write, no patient education tools, no clinical actions
+- **All agents LOCAL LLM only** — same rule applies; no gemini
+- **No Eir Gateway** — insurance is not an EHR system of record
+
+**Knowledge data populated:**
+- PrimeKG — same loaded (drug/disease knowledge for underwriting medical history analysis)
+- ICD-10-TM + TMT in MariaDB — TPC NOT loaded (procedures = hospital concern)
+- Insurance product catalogs (Prudential/ThaiLife/Thai Health) in tabular + vector
+- Underwriting manuals + exclusion catalogs in vector
+- PageIndex on: policy PDFs (50-200 page), claim documents, medical certificates submitted
+
+**RefGraph schema (per-deployment, insurance-flavored):**
+```
+(Applicant) -[:DIAGNOSED_WITH]-> (Condition) -[:SAME_AS]-> (PrimeKG:Disease)
+(Applicant) -[:PRESCRIBED]-> (Medication) -[:SAME_AS]-> (PrimeKG:Drug)
+(Applicant) -[:FILED_CLAIM]-> (Claim) -[:AGAINST_PRODUCT]-> (Product)
+(Product) -[:OFFERED_BY]-> (Insurer)
+(Product) -[:COVERS]-> (Condition)
+(Product) -[:EXCLUDES]-> (Condition)
+(Document) -[:ABOUT_APPLICANT]-> (Applicant)
+```
+
+**Hermodr tool catalog (insurance scope, ~30 tools — fewer than medical):**
+- `underwriter.*` (9) — case workflow + risk + fraud + analytics + HITL
+- `primekg.*` (6) — READ-ONLY clinical knowledge
+- `refgraph.*` (5) — applicant + product entity graph
+- `pageindex.*` (4) — policy/claim doc navigation
+- `mimir.search_chunks`
+- `icd10/tmt.lookup` — TPC not loaded
+- `clinical_calculator.*` (restricted to risk-relevant: eGFR, MELD, CHADS2 — not the full medical set)
+- `drug_interaction_check` (for applicant medication risk review)
+- `syn.extract` (claim doc + medical certificate OCR)
+- `audit.query`
+
+**Workflows:**
+- New case: Intake → OCR → Skuggi PII → Risk assessor → Medical analyzer → Fraud detector → Decision maker → HITL queue (low-conf) → PDF
+- Renewal: Pull case → re-assess → decision
+- Product comparison: across loaded insurers' catalogs
+
+### Components NOT installed on either tenant currently
+
+- Sága (STT, third-party Laminar) — future, both
+- Bragi (TTS) — future, both
+- Muninn (auto-fix) / Huginn (scanner) — private commercial; separate cybersecurity track
+- Odin — public, separate track
+
+## 3. Architecture Layers
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  USER (clinician / underwriter / portal bridge)                │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │ JWT (Yggdrasil RS256)
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  BIFROST  — orchestrator + tenant context + auth                │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  EIR-ROUTER  (decides which specialty: cardio/sleep/ent/peds)   │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │
+              ┌────────────────┴────────────────┐
+              ▼                                 ▼
+   ┌─────────────────────┐         ┌──────────────────────────┐
+   │ EIR specialty agent │         │  HEIMDALL (LLM gateway)  │
+   │ - reasoning loop    │◀───────▶│  - local MLX (default)   │
+   │ - tool calling      │         │  - cloud (via Skuggi)    │
+   └──────────┬──────────┘         └──────────────────────────┘
+              │ MCP tool invocation
+              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  HERMODR  — MCP tool catalog                                    │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────────────────┐  │
+│  │ primekg.*    │ │ refgraph.*   │ │ pageindex.*           │  │
+│  │ search/      │ │ entity_at/   │ │ pages_with_term/     │  │
+│  │ neighbors/   │ │ neighbors/   │ │ page_chunks/         │  │
+│  │ drug_inter   │ │ same_as      │ │ table_of_contents    │  │
+│  └──────┬───────┘ └──────┬───────┘ └──────────┬───────────┘  │
+│         │                │                     │              │
+│  ┌──────▼───────┐ ┌──────▼─────────────────────▼───────────┐  │
+│  │ mimir.search │ │ underwriter.*  /  syn.*  /  …          │  │
+│  └──────┬───────┘ └────────────────────────────────────────┘  │
+└─────────┼────────────────────────────────────────────────────────┘
+          │
+   ┌──────┴──────┬──────────┬─────────────┬──────────────┐
+   ▼             ▼          ▼             ▼              ▼
+┌──────┐   ┌──────────┐ ┌──────────┐ ┌──────────────┐ ┌────────┐
+│Qdrant│   │  Neo4j   │ │ Neo4j    │ │  MariaDB     │ │  S3/   │
+│chunks│   │ PrimeKG  │ │ RefGraph │ │  icd10_codes │ │ MinIO  │
+│+pages│   │ (public) │ │ (per-dep)│ │  cases,…     │ │ docs   │
+└──────┘   └──────────┘ └──────────┘ └──────────────┘ └────────┘
+      ▲           ▲           ▲              ▲           ▲
+      └───────────┴───────────┼──────────────┴───────────┘
+                              │
+              ┌───────────────┴────────────────┐
+              │  INGESTION PIPELINE            │
+              │  (asgard-doc-pipeline crate)   │
+              │                                │
+              │  raw file                      │
+              │   ↓ Syn (OCR)                  │
+              │   ↓ Skuggi (PII gate)          │
+              │   ↓ Chunking (recursive+Thai)  │
+              │   ↓ BGE-M3 embed               │
+              │   ↓ Qdrant upsert              │
+              │   ↓ RefGraph entity extract    │
+              │   ↓ Neo4j RefGraph upsert      │
+              │   ↓ PageIndex hierarchical idx │
+              │   ↓ SAME_AS link → PrimeKG     │
+              │   ↓ Tyr audit event            │
+              └────────────────────────────────┘
+```
+
+## 4. Knowledge Representations — Comparison
+
+Asgard maintains **4 complementary indexes**, each optimized for different query patterns:
+
+| Index | Storage | Granularity | Strength | Weakness | Update cost |
+|---|---|---|---|---|---|
+| **Vector chunks** | Qdrant | ~500-800 tokens | Semantic similarity, fuzzy match | No structure awareness, no exact lookup | Low (embed + upsert) |
+| **PrimeKG** | Neo4j (shared) | Entity (drug/disease/...) | Public medical knowledge, drug interactions, mechanism reasoning | Static, no customer data | One-time + monthly refresh |
+| **RefGraph** | Neo4j (per-deployment) | Entity + reference | Customer-specific entities, cross-doc resolution | Quality depends on extractor | Per-ingestion update |
+| **PageIndex** | Qdrant + DB | Page (PDF page) → chunks | Long-doc navigation, "show me page where X" | Storage 2× chunks | Same as chunks |
+| **SAME_AS** | Neo4j edges | Entity ↔ Entity | Bridge customer entities to public KG | Confidence depends on linker | Per-RefGraph build |
+
+### Query → Index routing
+
+| Query pattern | Primary index | Secondary | Example |
+|---|---|---|---|
+| "ยานี้รักษาอะไรได้" | PrimeKG | — | drug → indication relations |
+| "ผู้ป่วยรายนี้มีโรคอะไรบ้าง" | RefGraph | Tabular DB | case_id → diagnoses |
+| "ในกรมธรรม์ Prudential เขียนอย่างไรเรื่อง pre-existing" | Vector + PageIndex | — | semantic search → drill to page |
+| "ICD-10 ของเบาหวานชนิด 2 คืออะไร" | Tabular (icd10_codes) | — | exact lookup |
+| "เปรียบเทียบยา Atorvastatin กับ Rosuvastatin" | PrimeKG | Vector (clinical guidelines) | drug nodes + their indication neighbors |
+| "ระบุยาที่ห้ามใช้ในผู้ป่วยตั้งครรภ์" | PrimeKG (`contraindication`) | RefGraph (cross-reference patient history) | graph traversal |
+| "ผู้สมัครรายนี้มี risk factor อะไรบ้าง" | Tabular + RefGraph + PrimeKG | Vector (medical notes) | multi-source fusion |
+| "หน้าไหนของ chart พูดถึง CPAP titration" | PageIndex | Vector (chunks within page) | page-level → chunk-level drill |
+
+## 5. PageIndex — Detailed Design
+
+PageIndex is a **new pattern** Asgard should adopt for long-document corpora (policy PDFs, medical chart bundles, manuals).
+
+### Why PageIndex (vs flat chunk vector search alone)?
+
+Insurance policies are 50-200 page PDFs. A flat chunk vector search will:
+- Return chunks from random pages
+- Lose document hierarchy (sections, chapters)
+- Make "navigate to the part that says X" awkward
+- Fragment table-of-contents semantics
+
+PageIndex addresses these by maintaining a **hierarchical index**:
+
+```
+Document
+├── Section (Chapter 3: Pre-existing Conditions)
+│   ├── Page 47
+│   │   ├── Chunk 47.1 (paragraph A)
+│   │   ├── Chunk 47.2 (paragraph B)
+│   │   └── Chunk 47.3 (table)
+│   ├── Page 48
+│   └── Page 49
+└── Section (Chapter 4: Exclusions)
+```
+
+### Schema
+
+**Qdrant collections:**
+- `chunks-{tenant}` — chunk-level embeddings (existing)
+- `pages-{tenant}` — page-level embeddings (NEW): page = aggregate (mean or summary) of chunk embeddings on that page
+- `sections-{tenant}` — section-level embeddings (NEW, optional): for very-long docs
+
+**Metadata per page (in Qdrant + sidecar in DB):**
+```json
+{
+  "doc_id": "policy_prudential_term_v2",
+  "page_num": 47,
+  "section": "Pre-existing Conditions",
+  "section_id": "ch3",
+  "page_summary": "Defines pre-existing condition exclusions, waiver options, and look-back period of 24 months...",
+  "chunk_ids": ["c_47_1", "c_47_2", "c_47_3"],
+  "outline_level": 2,
+  "language": "th"
+}
+```
+
+### Retrieval modes
+
+1. **Direct chunk** (existing) — query → top-K chunks
+2. **Page-first** (NEW) — query → top-K pages → for each, list chunks (or summarize)
+3. **Section-first** (NEW) — query → top-K sections → drill into pages → drill into chunks
+4. **Outline (ToC)** (NEW) — return document outline with relevance scores per section/page (no chunk content)
+
+### Hermodr MCP tools
+
+```
+pageindex.search_pages(query, doc_id?, limit) → [{doc_id, page_num, score, summary}]
+pageindex.page_chunks(doc_id, page_num) → [chunks]
+pageindex.toc(doc_id) → document outline tree
+pageindex.section_chunks(doc_id, section_id) → [chunks]
+```
+
+### Effort estimate (new workstream)
+
+| Task | Effort |
+|---|---|
+| Page-level embedding generation (mean or summary) | 1d |
+| Qdrant `pages-{tenant}` collection + upsert pipeline | 1d |
+| Section detection (TOC parsing, heading extraction) | 2-3d |
+| 4 Hermodr MCP tools | 2d |
+| Eval set + benchmark | 1-2d |
+| **Total** | **~1.5 weeks** |
+
+→ **Recommended placement:** Underwriter v3 Phase C (after chunking remediation lands; PageIndex builds on improved chunking)
+
+## 6. RefGraph — Detailed Design
+
+RefGraph is a **per-deployment, document-derived knowledge graph** that complements PrimeKG.
+
+### Difference from PrimeKG
+
+| | PrimeKG | RefGraph |
+|---|---|---|
+| Source | Harvard biomedical KGs (20+ sources) | Customer's ingested documents |
+| Scope | Public medical knowledge | Customer-specific entities + relationships |
+| Update | One-time + Harvard releases | Continuous (every doc ingest) |
+| Persistence | Shared across deployments (same data on every box) | Unique per Mac mini |
+| Examples | "Metformin → indication → T2DM" | "Applicant APP-1234 → diagnosed with → T2DM" |
+
+### Pipeline (already in S1 Sprint)
+
+```
+Document chunks
+    ↓
+Entity extractor (refgraph-rs crate)
+    ↓
+Entity normalization (NER, ICD-10 lookup, TMT lookup)
+    ↓
+Relation extraction (chunk-local relations)
+    ↓
+Cross-chunk entity resolution (same entity mentioned in different places)
+    ↓
+RefGraph nodes + edges to Neo4j
+    ↓
+SAME_AS linking to PrimeKG (entity ID match or name match)
+```
+
+### Schema (S1-validated)
+
+**Nodes:**
+```
+(:RefGraph:Person {id, name, citizen_id_hash, ...})
+(:RefGraph:Condition {id, icd10_code, name, ...})
+(:RefGraph:Medication {id, tmt_code, name, dose, ...})
+(:RefGraph:Procedure {id, tpc_code, name, ...})
+(:RefGraph:Document {id, source, page, ...})
+(:RefGraph:Insurer {id, name})
+(:RefGraph:Product {id, name, type, insurer_id, ...})
+```
+
+**Edges:**
+```
+(Person)-[:DIAGNOSED_WITH {date, confidence, source_doc}]->(Condition)
+(Person)-[:PRESCRIBED {date, source_doc}]->(Medication)
+(Person)-[:UNDERWENT {date, source_doc}]->(Procedure)
+(Condition)-[:OBSERVED_IN]->(Document)
+(Product)-[:COVERS]->(Condition)
+(Product)-[:EXCLUDES]->(Condition)
+(RefGraph node)-[:SAME_AS {confidence, strategy}]->(PrimeKG node)
+```
+
+### Hermodr MCP tools (planned)
+
+```
+refgraph.entity_at(doc_id, page_num) → entities mentioned on this page
+refgraph.entity_neighbors(entity_id, hop=1) → connected entities
+refgraph.same_as(entity_id) → PrimeKG equivalent (if linked)
+refgraph.path(entity_a, entity_b, max_hops) → connection paths
+refgraph.cross_doc(entity_id) → all documents mentioning this entity
+```
+
+### Status & next steps
+
+- **S1 execution** (May 19-28 + Jun 2-11): Insurance products → RefGraph → search benchmark
+- **Post-S1 (Jun 13+):** generalize for medical records (Underwriter Phase C)
+- **Sprint 2 dependency:** RefGraph requires the trait-based extraction from ADR-003 to share types with the rest of the pipeline
+
+## 7. Retrieval Orchestration — How agents use these together
+
+### Pattern 1: Underwriting risk assessment (Eir-router)
+
+```
+User: "Assess risk for APP-1234"
+
+Agent steps:
+1. underwriter.case_get(APP-1234) → tabular case data + diagnoses + medications
+2. refgraph.entity_neighbors(APP-1234, hop=2) → connected entities
+   → find: Conditions {T2DM, HTN}, Medications {metformin, lisinopril}
+3. For each condition:
+   a. primekg.lookup_entity("T2DM") → PrimeKG node id
+   b. primekg.neighbors(node_id, relation="contraindication")
+      → drugs contraindicated in T2DM
+   c. Cross-check against patient's medications (RefGraph) for safety
+4. primekg.drug_interactions(metformin) → check against current medications
+5. underwriter.fraud_detect(claim history of APP-1234)
+6. Synthesize with Eir-cardio (because HTN + T2DM ⇒ cardiac risk specialty)
+7. Return: risk_score + per-tool reasoning trace + factor list
+```
+
+### Pattern 2: Policy interpretation (insurance underwriter chat)
+
+```
+User: "Does Prudential ProductX cover pre-existing diabetes?"
+
+Agent steps:
+1. pageindex.search_pages("pre-existing diabetes", doc_id="ProductX") → top-3 pages
+2. pageindex.page_chunks(doc_id, page_47) → full text of relevant page
+3. refgraph.entity_at(doc_id, page_47)
+   → find: Product { ProductX } -[:EXCLUDES]-> Condition { T2DM (E11.9) }
+4. mimir.search_chunks("exclusion clause diabetes ProductX") → vector hits for context
+5. Synthesize: "Pre-existing T2DM is excluded; see Section 3.4, page 47. Waiver via underwriting available per Section 3.5."
+```
+
+### Pattern 3: Medical chart query (clinician chat with Mega Care portal bridge)
+
+```
+User: "ผู้ป่วยรายนี้ควรปรับ CPAP อย่างไร" (patient context: HN-12345)
+
+Agent steps:
+1. underwriter.case_get(HN-12345) → patient context (OSA, AHI=35, weight, comorbid HTN)
+2. refgraph.entity_neighbors(HN-12345, hop=1) → patient's medications
+3. primekg.disease_drugs("Obstructive Sleep Apnea") → guideline-recommended interventions
+4. mimir.search_chunks("CPAP titration AHI moderate", filter="medical_guidelines")
+5. Route to Eir-sleep specialty agent
+6. Eir-sleep reasoning trace + final recommendation
+```
+
+## 8. MCP Tool Catalog (consolidated)
+
+Planned tools under Hermodr, organized by namespace:
+
+```
+# PrimeKG (medical knowledge)
+primekg.lookup_entity(name, type)
+primekg.neighbors(entity_id, relation, hop)
+primekg.drug_interactions(drug_id)
+primekg.disease_drugs(disease_id)
+primekg.symptom_to_disease(symptoms)
+primekg.path(from_id, to_id, max_hops)
+
+# RefGraph (document-derived KG)
+refgraph.entity_at(doc_id, page_num)
+refgraph.entity_neighbors(entity_id, hop)
+refgraph.same_as(entity_id)
+refgraph.path(entity_a, entity_b, max_hops)
+refgraph.cross_doc(entity_id)
+
+# PageIndex (long-doc nav)
+pageindex.search_pages(query, doc_id?, limit)
+pageindex.page_chunks(doc_id, page_num)
+pageindex.toc(doc_id)
+pageindex.section_chunks(doc_id, section_id)
+
+# Mimir (vector search)
+mimir.search_chunks(query, filter, limit)
+mimir.search_collection(collection, query, limit)
+
+# Tabular (icd/tmt/tpc lookup)
+icd10.lookup(query, mode, locale)
+tmt.lookup(query, locale)
+tpc.lookup(query, locale)
+
+# Underwriter (Asgard Insurance specific)
+underwriter.health_check()
+underwriter.case_get(case_id)
+underwriter.case_create(applicant_data, files)
+underwriter.risk_assess(applicant_id)
+underwriter.medical_analyze(applicant_id, doc_refs)
+underwriter.fraud_detect(claim_id)
+underwriter.decision(applicant_id)
+underwriter.portfolio_analytics(filters)
+underwriter.hitl_queue_status()
+
+# Syn (OCR)
+syn.extract(file_path, lang)
+syn.confidence_at(extraction_id, token_id)
+
+# Tyr (audit)
+audit.query(time_range, actor, action)
+```
+
+**Total:** ~35 tools at full rollout. Many of these are aliases/wrappers around Mimir + Neo4j queries.
+
+## 9. Constraints & Decisions
+
+| Constraint | Source | Impact |
+|---|---|---|
+| 1 Mac mini per customer, single-tenant | [ADR-009](../decisions/ADR-009-single-tenant-mac-mini-deployment.md) | All indexes per-box; no cross-customer; RefGraph deployment-scoped |
+| No cloud LLM unless Skuggi gates | [feedback memory](memory) | All retrieval happens locally; LLM synthesis local by default |
+| Rust-first | [memory](memory) | New components (PageIndex, additional tools) prefer Rust impl |
+| Local audit via Tyr or LocalDbSink | [ADR-002](../decisions/ADR-002-audit-sink-architecture.md) | Every tool invocation → audit event |
+| AGPL + Commercial dual license | [memory](memory) | All shared components publishable to crates.io |
+| FHIR R4 canonical types | planned ADR-006 | Tool outputs shape toward FHIR Resources |
+
+## 10. Phased Rollout
+
+### Phase 0 — Foundation (current)
+- ✅ PrimeKG in Neo4j (129K nodes)
+- ✅ ICD-10-TM anamai 2010 in tabular
+- ✅ Syn OCR shipped
+- ✅ Skuggi text Tier 1 shipped
+- ✅ Eir variants shipped
+- 🚫 Qdrant primekg-entities collection NOT populated (P.2 blocked on embedding service)
+- 🚫 Chunking has 3 critical issues (chunking audit, fix in Sprint 48)
+
+### Phase 1 — Knowledge Plumbing (Sprint 48 + Sprint 2 prep)
+- Fix chunking (PyThaiNLP wire + 800 token default + recursive port + benchmark)
+- Embed PrimeKG nodes → Qdrant
+- Synthetic Thai applicant generator
+- Medical retrieval benchmark queries
+
+### Phase 2 — Agent + MCP Tool Catalog (Sprint 2 Phase C)
+- 8 Underwriter MCP tools
+- PrimeKG tools (6)
+- ICD-10 / TMT / TPC lookup tools
+- Hermodr registration + Eir allowlist
+
+### Phase 3 — RefGraph Generalization (post-S1, Sprint 2-3)
+- Extract refgraph-rs into asgard-doc-pipeline-refgraph
+- 5 RefGraph MCP tools
+- SAME_AS pipeline to PrimeKG
+- Insurance + medical schema variants
+
+### Phase 4 — PageIndex (Sprint 3+)
+- Page-level embedding generation
+- Section detection
+- 4 PageIndex MCP tools
+- Eval benchmark (long-doc retrieval)
+
+### Phase 5 — Unified Retrieval Orchestrator (Sprint 4+)
+- Query planner: decide which indexes to hit for a given query
+- Multi-tool parallel invocation
+- Result fusion (RRF or learned)
+- Caching layer (hot queries)
+
+## 11. Open Questions
+
+1. **Page-level embedding aggregation strategy:** mean of chunk embeddings vs LLM-generated page summary embedding? Tradeoff: speed (mean is free) vs quality (summary preserves intent)
+2. **RefGraph re-derivation cost:** when a document is re-ingested with better chunking, do we re-extract entities? Likely yes, but need versioning strategy
+3. **PrimeKG version pinning vs auto-update:** monthly refresh as planned, or lock per-deployment so customers can validate before adopting new version
+4. **Query planner:** rule-based (decision tree of "if asking about X use Y") or learned (LLM-routed)? Rules are auditable; learning adapts. Start with rules.
+5. **Tool result caching:** for hot queries (e.g., common drug interactions), cache at Hermodr level or per-Mimir? Latency vs staleness tradeoff
+6. **SAME_AS confidence threshold:** when is a name-match good enough? PrimeKG SAME_AS uses 0.9 for name match; need calibration vs Thai names with multiple romanizations
+
+## 12. References
+
+- [ADR-001](../decisions/ADR-001-database-choice.md), [ADR-002](../decisions/ADR-002-audit-sink-architecture.md), [ADR-003](../decisions/ADR-003-shared-doc-pipeline-crate.md), [ADR-009](../decisions/ADR-009-single-tenant-mac-mini-deployment.md)
+- [Sprint tracker](../sprint_tracker_2026_05_17.md)
+- [PrimeKG data report](../../docs/reference/PRIMEKG_DATA_REPORT.md)
+- [Mimir chunking audit memory](memory)
+- [AWS QuickSuite comparison memory](memory)
+- [refgraph-rs](../../../refgraph-rs/) — S1 active work
+- PageIndex pattern: Microsoft Research, "Long-Context Retrieval via Hierarchical Page-Level Indexing" (concept; implementation Asgard-specific)

--- a/docs/architecture/fhir_r4_resource_selection.md
+++ b/docs/architecture/fhir_r4_resource_selection.md
@@ -1,0 +1,517 @@
+# FHIR R4 Resource Selection for Asgard
+
+**Status:** Draft v1
+**Date:** 2026-05-18
+**Sprint:** 2 W2.4
+**Scope:** Canonical patient-data types for the shared `asgard-doc-pipeline` crate
+**Audience:** internal engineering
+**Supersedes:** none
+**Related:** [ADR-003 trait + shared crate](../decisions/ADR-003-shared-doc-pipeline-crate.md), planned ADR-006 (FHIR canonical), [dataset inventory plan](../../../Mimir/docs/04_evaluation_and_testing/04_10_dataset_inventory_plan_2026-05-17.md)
+
+## 1. Goal
+
+Pick the **smallest FHIR R4 resource set** that lets Asgard:
+
+1. Represent patient data (medical chart OCR output, EHR ingest)
+2. Represent insurance workflow (policy, claim, coverage)
+3. Cross-domain integrate (insurance reads clinical, clinical writes insurance claims)
+4. Bind to Thai coding standards (ICD-10-TM, TMT, TPC, LOINC, SNOMED CT)
+5. Avoid over-implementation — full FHIR R4 has 150+ resources; we only need ~15
+
+The selected set lives in the new `asgard-doc-pipeline-core` crate as Rust types (per [ADR-003](../decisions/ADR-003-shared-doc-pipeline-crate.md) §B.3). Consumers: Underwriter v3, medical chart OCR (Syn extension), future Mega Care portal bridge, future Eir agent tool outputs.
+
+## 2. Non-goals
+
+- **NOT a FHIR REST server** — we shape types for in-process Rust use, not for serving `GET /Patient/{id}` HTTP endpoints (that's a future workstream if/when external EHR integration is needed)
+- **NOT exhaustive R4 coverage** — we skip resources that don't appear in any current workflow (e.g., Goal, CarePlan, NutritionOrder, Schedule, Slot)
+- **NOT R5 or USCDI** — Thai market is on R4; R5 transition is unscheduled
+- **NOT generic over all 150+ FHIR resources** — picking 15 means we can hand-tune Rust types, validation, and Thai profile extensions; a 150-resource library would force generic codegen patterns that miss Thai-specific needs
+
+## 3. Selection summary
+
+15 resources across 5 categories:
+
+| # | Resource | Why | Primary Asgard consumer |
+|---|---|---|---|
+| **Clinical (10)** | | | |
+| 1 | `Patient` | Identity, demographics, citizen_id, contact | All |
+| 2 | `Encounter` | Visit context, admission, OPD/IPD | Medical chart OCR, Underwriter |
+| 3 | `Observation` | Labs, vitals, sleep study metrics, BP/HR | Medical chart OCR, Eir-medtech |
+| 4 | `Condition` | Diagnoses with ICD-10-TM coding | All clinical reasoning |
+| 5 | `MedicationRequest` | Prescriptions with TMT coding | Eir-pharmacy, medical chart |
+| 6 | `MedicationStatement` | Patient-reported med adherence | Medical chart, Eir-pharmacy |
+| 7 | `Procedure` | Surgeries/procedures with TPC coding | Surgery, Underwriter pricing |
+| 8 | `DiagnosticReport` | Lab reports, sleep study reports | Eir-medtech |
+| 9 | `AllergyIntolerance` | Drug/food allergies, safety | Eir-pharmacy (mandatory check) |
+| 10 | `DocumentReference` | Pointer to scanned/OCR'd chart docs | Medical chart OCR, Mega Care bridge |
+| **Insurance (3)** | | | |
+| 11 | `Coverage` | Active policy + beneficiary linkage | Underwriter, claim flows |
+| 12 | `Claim` | Submitted insurance claim | Underwriter |
+| 13 | `ClaimResponse` | Adjudication outcome | Underwriter |
+| **Workflow / participants (2)** | | | |
+| 14 | `Practitioner` | Physician/nurse identity (writer of orders) | All |
+| 15 | `Organization` | Hospital/clinic/insurer entity | All |
+| **Collection wrapper** | | | |
+| (+) | `Bundle` | Wraps a set of resources for transport | All ingest/export |
+
+`Bundle` is foundational and is implicit — every persistent set of resources is a Bundle. Doesn't count toward the 15.
+
+## 4. Foundational datatypes (subset, included)
+
+These are FHIR primitive/complex datatypes used by the resources above. We implement these instead of pulling a generic FHIR datatype library:
+
+| Datatype | What it's for | Notes |
+|---|---|---|
+| `Identifier` | Business IDs (citizen_id, MRN, claim number) | Thai citizen_id system URI: `https://www.dopa.go.th/citizen-id` |
+| `CodeableConcept` | Code + display text (links to a Coding) | The atom of medical coding |
+| `Coding` | A single code from a code system | system + code + display |
+| `Reference` | Pointer to another resource | `Reference(Patient/123)` or absolute URL |
+| `HumanName` | Name parts (given, family, prefix) | Thai uses given+family only (no middle); prefix = นาย/นาง/นางสาว |
+| `Address` | Postal address | Thai uses subdistrict (ตำบล) / district (อำเภอ) / province |
+| `ContactPoint` | Phone/email | Thai phone format (+66 / 0XX) |
+| `Period` | Date range | Used in Encounter.period, Coverage.period |
+| `Quantity` | Numeric value with unit | Lab values, dose amounts |
+| `Money` | Currency-aware amount | THB for all financial; ISO-4217 currency code |
+| `Range` | Numeric range | Reference ranges in labs |
+| `Annotation` | Free-text note with author + timestamp | Clinician notes |
+
+We **do not** implement: `Attachment` body (just metadata via DocumentReference), `SampledData`, `Signature`, `Timing` (use ISO-8601 strings instead initially).
+
+## 5. Per-resource spec — what we include and skip
+
+For each resource we define a **lean Rust struct** with required fields + the optional fields Asgard actually uses. The full FHIR R4 spec has many optional fields we skip; we can extend later if a real consumer needs them.
+
+### 5.1 Patient (with Thai profile)
+
+```rust
+pub struct Patient {
+    pub id: Id,                        // UUID or stable hash
+    pub identifier: Vec<Identifier>,   // citizen_id, MRN, passport
+    pub active: bool,                  // default true
+    pub name: Vec<HumanName>,          // Thai + transliterated
+    pub gender: AdministrativeGender,  // male/female/other/unknown
+    pub birth_date: Option<NaiveDate>, // YYYY-MM-DD
+    pub address: Vec<Address>,
+    pub telecom: Vec<ContactPoint>,
+    pub marital_status: Option<CodeableConcept>,
+    pub deceased: Option<bool>,
+    pub general_practitioner: Vec<Reference>, // → Practitioner
+    pub managing_organization: Option<Reference>, // → Organization (hospital)
+}
+```
+
+**Thai profile (`ThaiPatient`) extends with:**
+- `identifier` MUST include one with `system = "https://www.dopa.go.th/citizen-id"` and `value = <13-digit Luhn-valid>`
+- `name` SHOULD include both Thai script (`use = "official"`) and Latin transliteration (`use = "usual"`)
+- `address.country = "TH"` for domestic patients
+- `address.line[0]` typically holds Thai house number + soi; `address.city = ตำบล`; `address.district = อำเภอ`; `address.state = จังหวัด`
+
+**Skipped (FHIR has but we don't use yet):** `photo`, `contact[]` (emergency contacts — defer), `communication.language`, `link[]` (patient merging).
+
+### 5.2 Encounter
+
+```rust
+pub struct Encounter {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,    // visit number, admission number
+    pub status: EncounterStatus,        // planned/in-progress/finished/cancelled
+    pub class: Coding,                  // OPD / IPD / ER / virtual
+    pub type_: Vec<CodeableConcept>,    // routine/follow-up/specialist
+    pub subject: Reference,             // → Patient (required)
+    pub participant: Vec<EncounterParticipant>, // → Practitioner
+    pub period: Option<Period>,         // start + end
+    pub reason_code: Vec<CodeableConcept>,
+    pub reason_reference: Vec<Reference>, // → Condition
+    pub diagnosis: Vec<EncounterDiagnosis>,
+    pub hospitalization: Option<EncounterHospitalization>, // admission details (IPD only)
+    pub service_provider: Option<Reference>, // → Organization
+}
+```
+
+**Encounter.class** is the OPD/IPD distinguisher — important for Thai claims (different e-Claim formats per setting).
+
+**Skipped:** `statusHistory`, `classHistory`, `length`, `account[]` (use Coverage instead).
+
+### 5.3 Observation
+
+```rust
+pub struct Observation {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,
+    pub status: ObservationStatus,      // registered/preliminary/final/amended/...
+    pub category: Vec<CodeableConcept>, // vital-signs / laboratory / imaging
+    pub code: CodeableConcept,          // LOINC code (e.g. 8480-6 = systolic BP)
+    pub subject: Reference,             // → Patient
+    pub encounter: Option<Reference>,
+    pub effective: Option<ObservationEffective>, // dateTime | Period
+    pub value: Option<ObservationValue>, // Quantity | string | CodeableConcept | Range | bool
+    pub interpretation: Vec<CodeableConcept>, // H/L/A flags
+    pub reference_range: Vec<ObservationReferenceRange>,
+    pub component: Vec<ObservationComponent>, // for compound observations (e.g. BP = sys+dia)
+}
+```
+
+**Code binding:** `Observation.code.coding` SHOULD use LOINC. For sleep-study metrics specifically (Mega Care domain):
+- LOINC `93832-4` = sleep study summary
+- LOINC `89026-8` = AHI (Apnea-Hypopnea Index)
+- LOINC `96532-9` = ODI (Oxygen Desaturation Index)
+- LOINC `8480-6` / `8462-4` = BP systolic/diastolic
+- LOINC `4548-4` = HbA1c
+- LOINC `2339-0` = glucose
+
+**Skipped:** `derivedFrom`, `hasMember`, `device`, `bodySite`.
+
+### 5.4 Condition (ICD-10-TM bound)
+
+```rust
+pub struct Condition {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,
+    pub clinical_status: Option<CodeableConcept>, // active/recurrence/relapse/inactive/resolved
+    pub verification_status: Option<CodeableConcept>, // unconfirmed/provisional/confirmed/refuted
+    pub category: Vec<CodeableConcept>,
+    pub severity: Option<CodeableConcept>,
+    pub code: CodeableConcept,          // PRIMARY: ICD-10-TM coding
+    pub subject: Reference,             // → Patient
+    pub encounter: Option<Reference>,
+    pub onset: Option<ConditionOnset>,  // dateTime | age | Period | Range
+    pub recorded_date: Option<DateTime>,
+    pub recorder: Option<Reference>,    // → Practitioner
+    pub note: Vec<Annotation>,
+}
+```
+
+**Thai profile (`ThaiCondition`):**
+- `code.coding[]` MUST include at least one with `system = "https://moph.go.th/icd10-tm/anamai-moph-2010"` (or successor source_version)
+- MAY include parallel SNOMED CT coding for cross-reference
+
+**Skipped:** `bodySite`, `stage`, `evidence`, `asserter` (use recorder for both).
+
+### 5.5 MedicationRequest (TMT bound)
+
+```rust
+pub struct MedicationRequest {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,
+    pub status: MedicationRequestStatus, // active/on-hold/cancelled/completed/...
+    pub intent: MedicationRequestIntent, // proposal/plan/order/...
+    pub category: Vec<CodeableConcept>,  // inpatient/outpatient/community
+    pub medication: MedicationReference, // CodeableConcept (TMT) | Reference(Medication)
+    pub subject: Reference,              // → Patient
+    pub encounter: Option<Reference>,
+    pub authored_on: Option<DateTime>,
+    pub requester: Option<Reference>,    // → Practitioner
+    pub reason_code: Vec<CodeableConcept>,
+    pub reason_reference: Vec<Reference>, // → Condition
+    pub dosage_instruction: Vec<Dosage>,
+    pub dispense_request: Option<DispenseRequest>,
+    pub substitution: Option<Substitution>,
+}
+```
+
+**Thai profile (`ThaiMedicationRequest`):**
+- `medicationCodeableConcept.coding[]` SHOULD include a TMT code (`system = "https://thaiindustrial.go.th/tmt"` or current TMT URI)
+- MAY include parallel RxNorm coding for international interop
+- `dosageInstruction[].text` SHOULD use Thai language by default; `dosageInstruction[].timing` carries structured frequency
+
+**Skipped:** `priorPrescription`, `detectedIssue[]` (use AllergyIntolerance + DDI tool output instead), `eventHistory`.
+
+### 5.6 MedicationStatement
+
+Same shape as MedicationRequest but:
+- Patient-reported ("I'm taking …") vs prescribed
+- Used for reconciliation, intake forms, OCR'd "current meds" sections
+- `status` enum smaller (active/completed/not-taken/...)
+
+### 5.7 Procedure (TPC bound)
+
+```rust
+pub struct Procedure {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,
+    pub status: ProcedureStatus,
+    pub category: Option<CodeableConcept>,
+    pub code: CodeableConcept,          // TPC (Thai Procedural Classification)
+    pub subject: Reference,             // → Patient
+    pub encounter: Option<Reference>,
+    pub performed: Option<ProcedurePerformed>, // dateTime | Period | Age | Range | string
+    pub recorder: Option<Reference>,
+    pub asserter: Option<Reference>,
+    pub performer: Vec<ProcedurePerformer>,
+    pub location: Option<Reference>,    // → Organization
+    pub reason_code: Vec<CodeableConcept>,
+    pub reason_reference: Vec<Reference>,
+    pub body_site: Vec<CodeableConcept>,
+    pub outcome: Option<CodeableConcept>,
+    pub note: Vec<Annotation>,
+}
+```
+
+**Thai profile:** `code.coding[]` SHOULD include TPC.
+
+### 5.8 DiagnosticReport
+
+Aggregates `Observation`s into a single report (lab report, sleep study report). Sleep clinic deliverable.
+
+```rust
+pub struct DiagnosticReport {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,
+    pub status: DiagnosticReportStatus,
+    pub category: Vec<CodeableConcept>,
+    pub code: CodeableConcept,          // LOINC for report type
+    pub subject: Reference,             // → Patient
+    pub encounter: Option<Reference>,
+    pub effective: Option<DiagnosticReportEffective>,
+    pub issued: Option<DateTime>,
+    pub performer: Vec<Reference>,
+    pub result: Vec<Reference>,         // → Observation (the actual values)
+    pub imaging_study: Vec<Reference>,  // → ImagingStudy (not implemented yet)
+    pub media: Vec<DiagnosticReportMedia>,
+    pub conclusion: Option<String>,
+    pub conclusion_code: Vec<CodeableConcept>,
+    pub presented_form: Vec<Attachment>, // PDF report — points to S3/MinIO URL
+}
+```
+
+### 5.9 AllergyIntolerance
+
+**Mandatory safety check** — eir-pharmacy MUST consult before any MedicationRequest action (per [Eir_Agents_Architecture §4.5](../../Eir/docs/Eir_Agents_Architecture.md)).
+
+```rust
+pub struct AllergyIntolerance {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,
+    pub clinical_status: Option<CodeableConcept>,
+    pub verification_status: Option<CodeableConcept>,
+    pub type_: Option<AllergyIntoleranceType>, // allergy | intolerance
+    pub category: Vec<AllergyIntoleranceCategory>, // food | medication | environment | biologic
+    pub criticality: Option<AllergyIntoleranceCriticality>, // low | high | unable-to-assess
+    pub code: CodeableConcept,          // substance code (TMT for drug, SNOMED for food)
+    pub patient: Reference,             // → Patient
+    pub onset: Option<AllergyOnset>,
+    pub recorded_date: Option<DateTime>,
+    pub recorder: Option<Reference>,
+    pub note: Vec<Annotation>,
+    pub reaction: Vec<AllergyReaction>,
+}
+```
+
+### 5.10 DocumentReference
+
+The bridge from OCR pipeline → FHIR. Each scanned chart + the extracted DiagnosticReport/Conditions all link back to one DocumentReference.
+
+```rust
+pub struct DocumentReference {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,
+    pub status: DocumentReferenceStatus,
+    pub doc_status: Option<DocumentReferenceDocStatus>,
+    pub type_: Option<CodeableConcept>,   // LOINC: e.g. 11502-2 = laboratory report
+    pub category: Vec<CodeableConcept>,
+    pub subject: Option<Reference>,       // → Patient
+    pub date: Option<DateTime>,
+    pub author: Vec<Reference>,           // → Practitioner | Organization
+    pub authenticator: Option<Reference>,
+    pub custodian: Option<Reference>,     // → Organization
+    pub relates_to: Vec<DocumentReferenceRelatesTo>,
+    pub description: Option<String>,
+    pub security_label: Vec<CodeableConcept>,
+    pub content: Vec<DocumentReferenceContent>, // file URI + mime-type + format
+    pub context: Option<DocumentReferenceContext>, // encounter, event, period
+}
+```
+
+**OCR pipeline integration:** Syn writes `DocumentReference` with `content[].attachment.url = "s3://asgard-medical-charts/{hash}.pdf"` + `content[].attachment.content_type = "application/pdf"`. Downstream `Condition`/`MedicationRequest` set `evidence.detail[]` referencing back to the DocumentReference.
+
+### 5.11 Coverage
+
+```rust
+pub struct Coverage {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,    // policy number
+    pub status: CoverageStatus,         // active/cancelled/draft/entered-in-error
+    pub type_: Option<CodeableConcept>, // HIP/EHCPOL/...
+    pub policy_holder: Option<Reference>,
+    pub subscriber: Option<Reference>,  // → Patient
+    pub subscriber_id: Option<String>,
+    pub beneficiary: Reference,         // → Patient (required)
+    pub dependent: Option<String>,
+    pub relationship: Option<CodeableConcept>, // self/spouse/child/...
+    pub period: Option<Period>,
+    pub payor: Vec<Reference>,          // → Organization (insurer)
+    pub class: Vec<CoverageClass>,      // plan tier
+    pub order: Option<u32>,             // primary/secondary
+    pub network: Option<String>,
+    pub cost_to_beneficiary: Vec<CoverageCostToBeneficiary>,
+    pub subrogation: Option<bool>,
+    pub contract: Vec<Reference>,
+}
+```
+
+**Thai insurance:** `payor` references the insurer Organization (Prudential / ThaiLife / Thai Health). `policy_holder` may differ from `beneficiary` (employer-paid plans). `network` describes provider network for in-network/out-of-network claim handling.
+
+### 5.12 Claim
+
+```rust
+pub struct Claim {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,    // claim number
+    pub status: FinancialResourceStatus,
+    pub type_: CodeableConcept,         // institutional/professional/pharmacy
+    pub sub_type: Option<CodeableConcept>,
+    pub use_: ClaimUse,                 // claim/preauthorization/predetermination
+    pub patient: Reference,             // → Patient
+    pub billable_period: Option<Period>,
+    pub created: DateTime,
+    pub enterer: Option<Reference>,
+    pub insurer: Option<Reference>,     // → Organization
+    pub provider: Reference,            // → Practitioner | Organization
+    pub priority: CodeableConcept,      // normal/stat/deferred
+    pub funds_reserve: Option<CodeableConcept>,
+    pub related: Vec<ClaimRelated>,
+    pub prescription: Option<Reference>, // → MedicationRequest
+    pub original_prescription: Option<Reference>,
+    pub payee: Option<ClaimPayee>,
+    pub referral: Option<Reference>,
+    pub facility: Option<Reference>,
+    pub care_team: Vec<ClaimCareTeam>,
+    pub supporting_info: Vec<ClaimSupportingInfo>,
+    pub diagnosis: Vec<ClaimDiagnosis>,
+    pub procedure: Vec<ClaimProcedure>,
+    pub insurance: Vec<ClaimInsurance>,
+    pub accident: Option<ClaimAccident>,
+    pub item: Vec<ClaimItem>,
+    pub total: Option<Money>,           // THB
+}
+```
+
+Long but each field maps to actual claim form requirements. Will likely trim during implementation if unused fields prove dead weight.
+
+### 5.13 ClaimResponse
+
+Adjudication result of a `Claim`. Mirrors Claim structure with `outcome`, `disposition`, `adjudication[]` per item, `total[]`, `payment`.
+
+### 5.14 Practitioner
+
+```rust
+pub struct Practitioner {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,    // medical license number, citizen_id
+    pub active: bool,
+    pub name: Vec<HumanName>,
+    pub telecom: Vec<ContactPoint>,
+    pub address: Vec<Address>,
+    pub gender: Option<AdministrativeGender>,
+    pub birth_date: Option<NaiveDate>,
+    pub qualification: Vec<PractitionerQualification>, // medical degree, board cert
+    pub communication: Vec<CodeableConcept>, // languages spoken
+}
+```
+
+### 5.15 Organization
+
+```rust
+pub struct Organization {
+    pub id: Id,
+    pub identifier: Vec<Identifier>,    // หสนเลขทะเบียน, HSN/THCC, NHSO provider code
+    pub active: bool,
+    pub type_: Vec<CodeableConcept>,    // hospital/clinic/insurer/payer
+    pub name: Option<String>,
+    pub alias: Vec<String>,
+    pub telecom: Vec<ContactPoint>,
+    pub address: Vec<Address>,
+    pub part_of: Option<Reference>,     // → Organization (parent)
+    pub contact: Vec<OrganizationContact>,
+    pub endpoint: Vec<Reference>,
+}
+```
+
+## 6. Thai profile constraints (summary)
+
+| Resource | Thai-specific constraint |
+|---|---|
+| Patient | Citizen ID identifier required, Thai script name MUST, address fields mapped to ตำบล/อำเภอ/จังหวัด |
+| Condition | At least one ICD-10-TM coding in `code.coding[]` |
+| MedicationRequest | TMT coding recommended in `medicationCodeableConcept.coding[]` |
+| Procedure | TPC coding recommended |
+| Coverage | `payor` Organization MUST be a registered Thai insurer per OIC list |
+| Money | currency MUST be "THB" by default; foreign currency allowed only via explicit `currency` |
+| Address | When country=TH: structure mapping per Thai postal hierarchy |
+
+## 7. Resources explicitly NOT included (v1)
+
+| Resource | Why excluded |
+|---|---|
+| `Goal`, `CarePlan` | No current workflow consumer |
+| `Schedule`, `Slot`, `Appointment` | Mega Care portal handles its own booking; FHIR appointment not needed in core types |
+| `Immunization` | Out of scope for Underwriter + Mega Care current focus |
+| `FamilyMemberHistory` | Underwriter captures family hx as `Patient`-level Booleans (simpler) |
+| `Specimen` | DiagnosticReport carries the lab values directly |
+| `ImagingStudy` | Defer until image-multimodal Eir Radiology ships (Sprint 45+) |
+| `Communication`, `CommunicationRequest` | Use HTTP audit + Tyr events instead |
+| `Task` | Workflow orchestration handled by Bifrost, not FHIR Task |
+| `Group` | No cohort use case yet |
+| `EpisodeOfCare` | Encounter is sufficient; nesting deferred |
+| `ExplanationOfBenefit` | Subset of ClaimResponse; cover with ClaimResponse extensions if needed |
+| `Contract` | Defer; Coverage covers the linkage we need |
+| `PaymentNotice`, `PaymentReconciliation` | Out of v1 scope |
+
+If a future workstream needs one, add to v2.
+
+## 8. Implementation note
+
+Two paths considered for the Rust types:
+
+### Option A: Hand-rolled types (recommended)
+Write the 15 resources + datatypes as plain Rust structs with `serde::{Serialize, Deserialize}`. Pros: full control, no codegen complexity, Thai profile types live alongside, smaller compile time. Cons: ~3-5 days to land all 15.
+
+### Option B: fhirbolt crate generation
+Use [`fhirbolt`](https://crates.io/crates/fhirbolt) (R4 typed generators). Pros: full FHIR R4 surface in one dep, kept current with HL7 spec releases. Cons: drags in all 150 resources whether we use them or not, codegen patterns may clash with our `asgard-doc-pipeline-core` traits, Thai profile extension requires runtime check rather than typed.
+
+**Decision:** Option A — hand-rolled for the 15. If a future workstream needs deep FHIR R4 (e.g. external EHR integration), introduce `fhirbolt` as a separate adapter crate at that boundary; don't pollute core.
+
+## 9. Validation strategy
+
+Per-resource validation lives in the type itself via constructor:
+
+```rust
+impl Patient {
+    pub fn new_thai(citizen_id: ThaiCitizenId, ...) -> Result<Self, ValidationError> {
+        // Validate Luhn checksum, name has Thai script, etc.
+    }
+}
+```
+
+Bulk validation utility:
+
+```rust
+pub fn validate_bundle(bundle: &Bundle) -> Vec<ValidationIssue>
+```
+
+Returns *all* issues, not first-fail, so importers can report comprehensively.
+
+Validation runs:
+1. On ingest (`asgard-doc-pipeline-core::ingest`) — log + reject non-conforming
+2. On export (FHIR REST endpoint when one exists) — refuse to emit invalid
+3. On test fixtures (CI) — every M3/I1 sample passes validation
+
+## 10. Cross-references
+
+- [ADR-003 trait-based extraction + shared crate](../decisions/ADR-003-shared-doc-pipeline-crate.md) — §B.3 lists FHIR core as a workspace member
+- [Solution architecture: Agent/MCP/RAG/Graph](agent_rag_graph_solution_architecture.md) — Per-tenant section mentions FHIR as canonical
+- [Underwriter v3 plan](../../../.claude/projects/-Users-mimir-Developer/memory/underwriter_v3_plan_decisions.md) — Phase B.3 schedules this work
+- [Eir Agents Architecture](../../Eir/docs/Eir_Agents_Architecture.md) — §3.1 agents `read_fhir` tool depends on these types
+- [Mega Care DATA_STANDARDS_RECOMMENDATIONS.md](../../../mega-care-admin-portal/docs/DATA_STANDARDS_RECOMMENDATIONS.md) — Mega Care side adopts the same R4 resources
+
+## 11. Decision log
+
+- 2026-05-18: Initial selection — 15 resources, hand-rolled, R4 only, Thai-profile via constraints. ADR-006 (to be written) will lock this.
+
+## 12. Open questions
+
+1. **Bundle entry typing:** `Bundle.entry[]` holds heterogeneous resources. Use Rust enum `BundleEntry { Patient(Patient), Condition(Condition), ... }` (closed, monomorphic) or `Box<dyn Resource>` (open, runtime dispatch)? Recommend enum for performance + exhaustive match safety.
+2. **Versioning:** R4 has FHIR resource `meta.versionId` + `meta.lastUpdated`. Do we track resource history in Asgard storage, or treat resources as immutable + audit via Tyr? Recommend latter for v1.
+3. **Schema discovery:** Should the crate expose JSON Schema for each Rust type so external consumers can validate? Recommend yes — generate with `schemars` crate.
+4. **Loose vs strict parsing:** Inbound FHIR from external systems may include fields we skip. Recommend deny-unknown-fields when reading our own data, allow-and-ignore when parsing external.
+5. **i18n / locale:** Should Rust types carry a `Locale` enum for which language the human-readable fields are in? Recommend no — store as `string` with optional `_language` extension per FHIR convention.

--- a/docs/decisions/ADR-001-database-choice.md
+++ b/docs/decisions/ADR-001-database-choice.md
@@ -1,0 +1,154 @@
+# ADR-001: Database Choice for Asgard-Underwriter Persistence
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Deciders:** paripol@megawiz.co
+**Context for:** Asgard-Underwriter v2.2.1 → v3.0 Phase A.1 — DB persistence
+**Supersedes:** none
+**Superseded by:** none
+
+## Context
+
+Asgard-Underwriter v2.2.1 currently stores all case data, file metadata, chat sessions, HITL queue, and audit events in an in-memory `HashMap` within `iris/src/main.rs`. This blocks production deployment for any customer:
+
+- Case data lost on restart
+- "Persistent chat sessions" (per RELEASE_NOTES) are not actually persistent
+- HITL queue cannot survive a process crash
+- No audit trail for compliance (HIPAA/PDPA)
+- Cannot scale beyond a single process (though scaling is not a near-term goal given 1-Mac-mini-per-customer deployment)
+
+We need a real database. The Asgard stack already runs MariaDB and Postgres in K8s (`asgard-infra` namespace, per [memory](memory)). The decision is which to use for Underwriter — and whether to consider this a forcing function to consolidate the platform onto one database.
+
+## Decision
+
+**Use MariaDB** as the primary database for Asgard-Underwriter.
+
+- Connection via `sqlx` with compile-time checked queries
+- Migrations via `sqlx-migrate`
+- One database per Underwriter deployment (since 1 Mac mini = 1 customer, no shared DB)
+- Schema lives in `iris/migrations/`
+
+We do **not** migrate the wider Asgard stack to Postgres at this time, even though Postgres has clear advantages for Underwriter-specific workloads (audit hash chain, JSONB policy metadata, pgvector for similarity dedup).
+
+## Alternatives Considered
+
+### 1. PostgreSQL (rejected for now, kept as future option)
+
+**Advantages for Underwriter specifically:**
+- `audit_events` hash chain — Postgres triggers + JSONB make this cleaner
+- Dedup similarity ≥0.95 — pgvector ships in-DB instead of round-tripping to Mimir/Qdrant
+- Policy metadata JSONB query — per-insurer schema flexibility without table-per-insurer
+- Better text search for chat history (full-text + trigram indexes)
+- Better Rust ecosystem alignment (sqlx, sea-orm both treat Postgres as primary target)
+
+**Why rejected (for now):**
+- Bifrost stack uses MariaDB (`agent_configs` table per [asgard_agent_registry memory](memory)); Sprint 51e rotation of MariaDB just completed (per [rotation memory](memory))
+- Per-customer Postgres adds operational complexity to Mac-mini installs (one more daemon to manage, backup, monitor)
+- Platform-wide migration is too large to attempt while juggling S1 RefGraph (May 19-28 + June 2-11)
+- Underwriter Phase A.1 needs to ship before optimizing for Postgres-specific features
+
+**Future trigger:** if benchmark shows audit hash chain or dedup similarity is a real bottleneck on MariaDB, revisit per-component switch.
+
+### 2. SQLite (rejected)
+
+- Excellent for single-process per-Mac-mini deployment
+- File-based, trivial backup
+- Zero ops complexity
+
+**Why rejected:**
+- Concurrent write scaling poor (WAL helps but not enough for HITL + audit + case write churn)
+- Tooling around audit trail, retention, and Tyr export is heavier for SQLite (no standard tools)
+- Less production-tested for healthcare-adjacent workloads
+- Migration path to MariaDB/Postgres later is non-trivial (SQL dialect divergence)
+
+### 3. Keep HashMap + periodic snapshot to disk (rejected)
+
+- Zero migration effort
+- Predictable performance
+
+**Why rejected:**
+- Doesn't solve any of the actual problems (audit, multi-process survival, transactional consistency)
+- Sunk-cost trap — would have to migrate later anyway
+- Cannot pass PDPA/HIPAA audit requirements
+
+### 4. sled / RocksDB embedded KV (rejected)
+
+- Rust-native, no external service
+- Fast
+
+**Why rejected:**
+- Not SQL — every query becomes manual code
+- No standard reporting tooling
+- Schema migrations become application-level concerns
+- Wrong abstraction level for relational data (cases ↔ files ↔ extractions ↔ HITL)
+
+## Consequences
+
+### Positive
+
+- **Stack consistency:** MariaDB is already the transactional DB in Asgard (Bifrost `agent_configs`); ops team already knows it
+- **Per-customer simplicity:** each Mac mini runs one MariaDB instance, no Postgres-MariaDB dual operate
+- **Rotation tested:** MariaDB rotation just passed in Sprint 51e (May 11) — mature operational pattern
+- **Backup story:** `mysqldump` + binlog established
+- **Skill match:** developer (paripol) already familiar with MariaDB from existing Asgard work
+
+### Negative
+
+- **JSONB pain:** MariaDB JSON support is workable but weaker than Postgres JSONB; policy metadata queries will need more application-side filtering
+- **No pgvector:** dedup similarity calculation must round-trip to Mimir/Qdrant for vector ops; adds latency to S2 multi-insurer dedup workflow
+- **Hash chain awkwardness:** audit chain integrity needs application-level enforcement (vs Postgres triggers); see [ADR-002](ADR-002-audit-sink-architecture.md) for compensating design
+- **Future migration cost:** if a future customer or workload mandates Postgres, per-component switching is workable but not free
+
+### Risks accepted
+
+- Cannot leverage pgvector for in-DB similarity → must keep Qdrant in the loop for dedup
+- JSON column queries will be slower than equivalent Postgres JSONB queries
+- If Postgres-specific features become required later, switch effort is ~1 sprint per affected component
+
+## Implementation Notes
+
+### Schema scope (10 tables for v3.0)
+
+```
+cases               case_id, tenant_id, insurer_id, status, risk_score, ...
+case_files          file_id, case_id, file_hash, file_type, ocr_status, ...
+extractions         extraction_id, case_id, file_id, raw_text, structured_json, ...
+diagnoses           id, case_id, icd10_code, source_extraction_id
+medications         id, case_id, drug_name, dose, frequency, source_extraction_id
+hitl_queue          queue_id, case_id, assignee, sla_deadline, escalation_level, ...
+chat_sessions       session_id, case_id, created_at, updated_at
+chat_messages       message_id, session_id, role, content, timestamp
+audit_events        event_id, actor, action, resource, before_hash, after_hash, ts
+pii_detections      detection_id, case_id, file_id, pii_type, bbox, redacted, ts
+```
+
+### Library choices
+
+- **sqlx 0.7+** — compile-time SQL verification, no ORM overhead, async-native
+- **sqlx-migrate** — file-based migrations with up/down support
+- **testcontainers-rs** — spin up real MariaDB for integration tests, no mocks
+
+### Migration discipline
+
+- Every schema change is a numbered migration file (`migrations/0001_initial.sql`, `0002_audit_hash_chain.sql`, ...)
+- Migrations are idempotent (re-runnable)
+- Down migrations required for all up migrations (rollback discipline)
+- CI fails if migrations don't apply cleanly on a blank DB
+
+## Validation
+
+This decision is validated when:
+
+- [ ] sqlx + migrations integrated into iris build
+- [ ] 10 tables defined with FK + indexes
+- [ ] testcontainers integration test passes on clean DB
+- [ ] All 159 existing backend tests pass with DB-backed services
+- [ ] All 10 E2E tests pass with DB-backed services
+- [ ] Restart server → case data, chat history, HITL queue, audit log all preserved
+
+## References
+
+- [Asgard stack in OrbStack K8s memory](memory)
+- [Sprint 51e rotation status memory](memory) — MariaDB recently rotated
+- [underwriter_v3_plan_decisions memory](memory) — MariaDB locked 2026-05-17
+- [Asgard-Underwriter v2.2.1 codebase audit](../sprint_tracker_2026_05_17.md)

--- a/docs/decisions/ADR-002-audit-sink-architecture.md
+++ b/docs/decisions/ADR-002-audit-sink-architecture.md
@@ -1,0 +1,208 @@
+# ADR-002: Audit Sink Architecture for Asgard-Underwriter
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Deciders:** paripol@megawiz.co
+**Context for:** Asgard-Underwriter v2.2.1 → v3.0 Phase A.2 — Tyr audit integration
+**Related:** [ADR-001](ADR-001-database-choice.md), [feedback_include_tyr_in_pii_designs memory](memory)
+
+## Context
+
+The Asgard platform has a hard rule (recorded as `feedback_include_tyr_in_pii_designs`): any PII/medical/external-doc/regulated-decision workflow must include Tyr as a **first-class** detection and audit layer — not an afterthought.
+
+Asgard-Underwriter handles PHI from insurance applicants every time a case is created. Without an audit trail, the system cannot pass PDPA or HIPAA-equivalent compliance reviews. Current v2.2.1 has zero audit logging — this is a compliance blocker, not a nice-to-have.
+
+The complication: **Tyr (Wazuh-based SIEM) is currently scaled down** (per [tyr_wazuh_scaled_down memory](memory)). The full Wazuh deployment is not always available. We cannot let audit functionality depend on Tyr being up — that would block production.
+
+We need an audit architecture that:
+1. **Always logs**, even when Tyr is down
+2. **Tamper-evident** — modifying past entries must be detectable
+3. **Pluggable sinks** — can target local DB, Wazuh, or both
+4. **Forward-compatible** — when Tyr scales back up, no code change required, just config
+
+## Decision
+
+**Implement audit as a Rust trait with multiple sink implementations.** Underwriter writes audit events through a sink trait. Default config: LocalDbSink + Wazuh stub fan-out.
+
+```rust
+#[async_trait]
+pub trait AuditSink: Send + Sync {
+    async fn emit(&self, event: AuditEvent) -> Result<()>;
+}
+
+pub struct LocalDbSink { pool: MariaDbPool }
+pub struct TyrWazuhSink { client: WazuhClient }  // stub until Tyr scales up
+pub struct FanoutSink { sinks: Vec<Arc<dyn AuditSink>> }
+```
+
+**Default deployment configuration:**
+
+```
+AUDIT_SINK=fanout
+AUDIT_FANOUT=local,wazuh-stub
+```
+
+- `LocalDbSink` writes to MariaDB `audit_events` table (per ADR-001)
+- `TyrWazuhSink` POSTs to Wazuh HTTP receiver endpoint (or no-ops if endpoint not configured)
+- `FanoutSink` writes to both — local always succeeds, Wazuh failure is logged but does not fail the request
+
+**Tamper-evidence via hash chain.** Each `audit_events` row has:
+
+- `event_id` UUID
+- `prev_event_hash` SHA-256 of previous event row (per actor or globally — see implementation note)
+- `event_hash` SHA-256 of (this event's content || prev_event_hash)
+
+Modifying any past event breaks the chain. A verifier job (`scripts/verify_audit_chain.sh`) walks the chain and reports the first broken link.
+
+## Alternatives Considered
+
+### 1. Direct Tyr/Wazuh integration only (rejected)
+
+- Single sink, simpler code
+
+**Why rejected:**
+- Tyr is scaled down; depending on it would mean audit failures during downtime
+- Tightly couples Underwriter to Wazuh's deployment lifecycle
+- Underwriter must work standalone on a customer Mac mini even if customer never scales up Wazuh
+
+### 2. Local-only sink, defer Tyr forever (rejected)
+
+- Write only to MariaDB; never touch Wazuh
+
+**Why rejected:**
+- Memory rule says Tyr must be first-class, not deferred indefinitely
+- Building Wazuh integration later means revisiting every event-emission call site
+- Stub now is cheap; integration later via config flip is the right pattern
+
+### 3. Append-only log file (rejected)
+
+- Write JSON lines to a rotated log file; cron-ship to S3 / Wazuh / etc.
+
+**Why rejected:**
+- File-based logs are easy to rotate and lose
+- No query API for audit lookups during incident response
+- Hash chain enforcement is awkward across rotated files
+- MariaDB row-level approach gives us SQL queries + ACID transactions for free
+
+### 4. Postgres-native audit (rejected — for now)
+
+- Postgres triggers + JSONB for richer semantics
+
+**Why rejected:**
+- Conflicts with ADR-001 (MariaDB first)
+- Can revisit when/if Postgres switch happens
+
+### 5. Trust the application — no audit (rejected)
+
+- Skip audit entirely
+
+**Why rejected:**
+- Violates compliance hard rule
+- Memory `feedback_include_tyr_in_pii_designs` says first-class, non-negotiable
+
+## Consequences
+
+### Positive
+
+- **Always-on audit** — local sink works without external dependencies
+- **Forward path to Tyr** — config flip, no code change
+- **Tamper-evident** — hash chain detects retroactive modification
+- **Per-deployment** — fits on-prem appliance model from [ADR-009](ADR-009-single-tenant-mac-mini-deployment.md)
+- **Reusable** — the trait + sinks also serve PrimeKG/Mega Care workstream (Phase 5 audit) without rewrite
+
+### Negative
+
+- **Hash chain in app code** (not Postgres trigger) — see ADR-001 trade-offs
+- **Wazuh stub** is a stub; integration tests with real Wazuh are deferred until Tyr scales
+- **Storage growth** — audit_events table grows monotonically; need retention runbook (probably ship rotation to cold storage after N days)
+- **Performance overhead** — every write path emits an event; ~1 extra DB row per case operation. Acceptable at expected scale.
+
+### Risks
+
+- **Hash chain bug ships with no detection** — if hash computation has a bug, all rows are technically valid but verification would fail. Mitigation: unit-test chain construction + verify on every CI run
+- **Wazuh schema drift** — when Tyr scales up, Wazuh expectations may have evolved. Mitigation: stub format follows current Wazuh JSON spec, adapter updates on integration
+
+## Implementation Notes
+
+### Critical events that MUST emit (Phase A.2 minimum)
+
+| # | Event | Trigger |
+|---|---|---|
+| 1 | `case.created` | New case via `POST /api/v1/cases` |
+| 2 | `case.modified` | Case fields updated |
+| 3 | `case.deleted` | Case removed |
+| 4 | `file.uploaded` | New file attached, includes file hash |
+| 5 | `file.downloaded` | File retrieved (data exfiltration trail) |
+| 6 | `extraction.completed` | OCR + structured extraction finished |
+| 7 | `pii.detected` | Skuggi PII hit |
+| 8 | `manual_review.escalated` | Extraction → HITL queue |
+| 9 | `hitl.assigned` | Queue item assigned to reviewer |
+| 10 | `hitl.decision` | Reviewer accept/reject/modify |
+| 11 | `assessment.decided` | Final risk score assigned |
+| 12 | `pdf.exported` | Case report PDF generated |
+| 13 | `auth.success` / `auth.failure` | Once JWT lands (Phase A.3) |
+
+### Event schema
+
+```rust
+pub struct AuditEvent {
+    pub event_id: Uuid,
+    pub ts: DateTime<Utc>,
+    pub actor: Actor,               // tenant_id + user_id + source_ip
+    pub action: String,             // dotted lowercase, e.g. "case.created"
+    pub resource: ResourceRef,      // type + id, e.g. ("case", "c_a1b2...")
+    pub severity: Severity,         // info / notice / warning / critical
+    pub before: Option<JsonValue>,  // hash of pre-state (NOT raw — PHI safety)
+    pub after: Option<JsonValue>,   // hash of post-state
+    pub metadata: JsonValue,        // event-specific extras
+    pub prev_event_hash: [u8; 32],
+    pub event_hash: [u8; 32],
+}
+```
+
+### Hash chain scope
+
+Two reasonable choices:
+- **Global chain** — one chain across all events. Simple, but every write contends on tail
+- **Per-actor chain** — chain segmented by actor (user). No contention; but actor switching obscures cross-actor correlation
+
+**Decision:** start with **global chain** for v3.0. If contention shows up in load tests (Phase D.2), partition to per-table or per-actor. The verifier supports both.
+
+### Wazuh stub specifics
+
+```rust
+impl AuditSink for TyrWazuhSink {
+    async fn emit(&self, event: AuditEvent) -> Result<()> {
+        if self.client.endpoint.is_none() {
+            return Ok(());  // no-op, stub mode
+        }
+        // POST to Wazuh HTTP receiver, fire-and-forget with bounded retry
+        // Body: Wazuh-compatible JSON envelope around AuditEvent
+    }
+}
+```
+
+### Retention policy (out of scope for v3.0)
+
+- Default: keep all events forever locally
+- Future: configurable retention window + cold-storage shipping
+- Compliance: must comply with both PDPA (Thai) and any sector-specific rules; document per customer
+
+## Validation
+
+This decision is validated when:
+
+- [ ] `AuditSink` trait defined + 3 impls (LocalDbSink, TyrWazuhSink, FanoutSink)
+- [ ] All 13 critical events emit through the sink in normal flow
+- [ ] `verify_audit_chain.sh` walks the chain and reports OK on a clean run
+- [ ] Tamper test passes: manually UPDATE a row → verifier reports broken link with row number
+- [ ] Wazuh stub: when endpoint unconfigured, all emits succeed and no errors logged
+- [ ] Wazuh stub: when endpoint configured but unreachable, local sink still succeeds, Wazuh failure is logged at WARN, no request failure propagates
+
+## References
+
+- [feedback_include_tyr_in_pii_designs memory](memory)
+- [tyr_wazuh_scaled_down memory](memory)
+- [asgard_tyr_siem memory](memory) — Tyr architecture
+- [ADR-001](ADR-001-database-choice.md) — MariaDB foundation
+- [ADR-009](ADR-009-single-tenant-mac-mini-deployment.md) — per-deployment audit, no cross-box SIEM

--- a/docs/decisions/ADR-003-shared-doc-pipeline-crate.md
+++ b/docs/decisions/ADR-003-shared-doc-pipeline-crate.md
@@ -1,0 +1,268 @@
+# ADR-003: Trait-based Extraction & Shared `asgard-doc-pipeline` Crate
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Deciders:** paripol@megawiz.co
+**Context for:** Asgard-Underwriter v3 Phase B + Medical Chart OCR (Syn extension) + future Mega Care portal bridge
+**Related:** [ADR-001](ADR-001-database-choice.md), [ADR-002](ADR-002-audit-sink-architecture.md), [feedback_consolidate_overlap_early memory](memory)
+
+## Context
+
+Asgard has at least three workstreams that need essentially the same document pipeline:
+
+1. **Asgard-Underwriter** — claim/policy/medical-record document ingestion for insurance underwriting
+2. **Medical Chart OCR (Syn extension)** — handwritten doctor chart OCR for medical platform deployments
+3. **Mega Care portal bridge (future)** — patient document flow from sleep clinic portal into Asgard medical workflow
+
+Audit of Asgard-Underwriter v2.2.1 found `iris/src/extraction.rs` is **~60% generic, ~40% tangled with underwriting workflow** (ICD-10 mapping, risk scoring, insurance scoring assumptions baked in alongside generic Syn/Mimir orchestration).
+
+User has decided ([feedback_consolidate_overlap_early memory](memory)) that overlapping pipelines should be consolidated **upfront** rather than allowed to fork-then-converge. The principle is recorded; this ADR specifies how.
+
+## Decision
+
+Refactor `iris/src/extraction.rs` to trait-based design, then **extract a shared workspace crate `asgard-doc-pipeline` and publish to crates.io as AGPL-3.0 + Commercial dual** (per [feedback_asgard_license memory](memory)).
+
+### Crate workspace structure
+
+```
+asgard-doc-pipeline/                       (workspace root)
+├── Cargo.toml                             (workspace manifest)
+├── README.md
+├── LICENSE-AGPL.md
+├── LICENSE-COMMERCIAL.md
+└── crates/
+    ├── core/                              # asgard-doc-pipeline-core
+    │   ├── traits.rs                      # DocumentSource, OcrBackend, PiiGate, ...
+    │   ├── types/
+    │   │   ├── fhir/                      # FHIR R4 resources (~15 selected)
+    │   │   ├── thai/                      # Thai profile (citizen_id, address)
+    │   │   └── ocr.rs                     # OcrOutput, Confidence, Bbox
+    │   └── audit.rs                       # AuditEvent shape (consumer of ADR-002 sink)
+    │
+    ├── ocr-syn/                           # asgard-doc-pipeline-ocr-syn
+    │   └── ...                            # Syn HTTP client impl of OcrBackend
+    │
+    ├── pii-skuggi/                        # asgard-doc-pipeline-pii-skuggi
+    │   └── ...                            # Skuggi adapter impl of PiiGate
+    │
+    ├── audit-tyr/                         # asgard-doc-pipeline-audit-tyr
+    │   └── ...                            # AuditSink impls (LocalDb, Wazuh stub, Fanout) — moved from Underwriter once stable
+    │
+    ├── storage/                           # asgard-doc-pipeline-storage
+    │   └── ...                            # DB abstraction (MariaDB-first, Postgres-ready) — sqlx traits
+    │
+    ├── lexicon-primekg/                   # asgard-doc-pipeline-lexicon-primekg
+    │   └── ...                            # PrimeKG-backed LexiconValidator
+    │
+    └── pipeline/                          # asgard-doc-pipeline (composed default)
+        ├── default.rs                     # Wires core + Syn + Skuggi + Tyr + storage
+        └── examples/
+            └── minimal-pipeline.rs        # Smoke test: file → extracted FHIR Bundle
+```
+
+### Core traits
+
+```rust
+// crates/core/src/traits.rs
+
+#[async_trait]
+pub trait DocumentSource: Send + Sync {
+    fn file_type(&self) -> FileType;
+    fn bytes(&self) -> &[u8];
+    fn hash(&self) -> &str;            // SHA-256 hex of bytes
+    fn metadata(&self) -> &DocumentMetadata;
+}
+
+#[async_trait]
+pub trait OcrBackend: Send + Sync {
+    async fn extract(&self, src: &dyn DocumentSource) -> Result<OcrOutput>;
+    fn name(&self) -> &str;            // "syn-typhoon", "tesseract", ...
+    fn confidence_threshold(&self) -> f32;
+}
+
+#[async_trait]
+pub trait PiiGate: Send + Sync {
+    async fn check_text(&self, text: &str) -> PiiResult;
+    async fn check_image(&self, src: &dyn DocumentSource) -> PiiResult;
+    /// Pixel-blackout regions in image; returns redacted bytes.
+    async fn redact_pixels(&self, src: &dyn DocumentSource, regions: &[Bbox]) -> Result<Vec<u8>>;
+}
+
+#[async_trait]
+pub trait LexiconValidator: Send + Sync {
+    /// Re-rank OCR candidates against a domain lexicon (e.g., PrimeKG, insurance terms).
+    /// Returns same candidates with adjusted confidence scores.
+    async fn validate(&self, candidates: Vec<Candidate>) -> Result<Vec<Candidate>>;
+}
+
+#[async_trait]
+pub trait DisambiguationAgent: Send + Sync {
+    /// For low-confidence tokens, use surrounding context to propose better candidates.
+    async fn disambiguate(&self, ctx: &DocumentContext, token: &UncertainToken)
+        -> Result<DisambiguationResult>;
+}
+
+#[async_trait]
+pub trait StructuredExtractor<T>: Send + Sync {
+    /// Convert raw OCR output + validated lexicon hits into domain-specific structured data.
+    async fn extract_structured(&self, ocr: &OcrOutput) -> Result<T>;
+}
+```
+
+### What stays Underwriter-specific (does NOT move to shared crate)
+
+```rust
+// iris/src/extraction.rs (after refactor)
+
+pub struct InsuranceClaimData {
+    pub diagnoses: Vec<Diagnosis>,           // ICD-10-TM coded
+    pub medications: Vec<Medication>,        // TMT coded
+    pub labs: Vec<Lab>,                      // LOINC coded
+    pub procedures: Vec<Procedure>,          // TPC coded
+    pub provider: Provider,
+    pub coverage: Option<Coverage>,
+    pub risk_factors: Vec<RiskFactor>,       // Underwriting-specific
+}
+
+pub struct UnderwriterExtractor { /* deps */ }
+
+#[async_trait]
+impl StructuredExtractor<InsuranceClaimData> for UnderwriterExtractor {
+    async fn extract_structured(&self, ocr: &OcrOutput) -> Result<InsuranceClaimData> {
+        // Underwriting-specific orchestration: ICD-10 lookup, drug normalization,
+        // risk scoring inputs, FHIR Claim resource shaping
+        ...
+    }
+}
+```
+
+Medical chart OCR will define its own `ClinicalChartData` extractor that ALSO uses the shared crate. Mega Care portal bridge will use `StructuredExtractor<SleepStudyData>` later.
+
+### Publishing strategy
+
+**crates.io public from v0.1.0**, AGPL-3.0 + Commercial dual license (per [feedback_asgard_license memory](memory)).
+
+- `v0.1.x` — experimental API, breaking changes allowed (semver allows this pre-1.0)
+- `v1.0.0` — locked after Underwriter v3 ships AND medical chart OCR ships AND used in anger for at least 2 sprints
+- License headers on every file; LICENSE-AGPL.md + LICENSE-COMMERCIAL.md at workspace root
+
+## Alternatives Considered
+
+### 1. Fork from Underwriter, consolidate later (rejected — earlier decision)
+
+User explicitly rejected this 2026-05-17 in conversation, leading to memory `feedback_consolidate_overlap_early`. ADR-003 codifies that decision.
+
+### 2. Keep monorepo, no separate crate (rejected)
+
+- Put traits in Underwriter, have medical chart OCR depend on Underwriter
+
+**Why rejected:**
+- Forces medical chart OCR to pull insurance dependencies it doesn't need
+- Underwriter becomes a load-bearing public dependency for medical chart pipelines
+- Discourages clean separation (slippery slope back to tangle)
+
+### 3. Single mega-crate instead of workspace (rejected)
+
+- All traits + Syn adapter + Skuggi adapter + storage in one crate
+
+**Why rejected:**
+- Consumers (medical chart OCR, Mega Care bridge) drag in all adapters even if they only use one
+- Compile time explodes
+- Update churn: bumping the Syn adapter forces all consumers to recompile
+- Workspace with feature-flagged sub-crates is the Rust idiom for this
+
+### 4. Internal git dependency (no crates.io) (rejected)
+
+- Workspace, but don't publish
+
+**Why rejected:**
+- Friction for any external collaborator
+- crates.io is the discovery surface; user wants Asgard visible per AGPL+Commercial moat (memory `feedback_asgard_license`)
+- Versioning discipline weaker on git deps
+- Lock-step updates harder
+
+### 5. Wait until Underwriter v3 ships, then extract (rejected)
+
+- Refactor + extract is risky; do it after stabilizing v3
+
+**Why rejected:**
+- Refactor cost grows with code drift
+- Medical chart OCR (W3) is gated on the shared crate; deferring extraction delays W3 by weeks
+- Underwriter v3 Phase B is the right slot — it includes the trait refactor anyway
+
+## Consequences
+
+### Positive
+
+- **DRY across workstreams** — Underwriter, medical chart OCR, Mega Care bridge consume one library
+- **License + moat** — public AGPL crate is the open-core surface; commercial license is the revenue surface
+- **Forced abstraction discipline** — extracting to a separate crate stops you from sneaking in domain-specific types
+- **External adoption surface** — third parties (other Thai medical AI startups, hospital integrators) can build on the same pipeline
+- **Test isolation** — shared crate has its own mocks + integration tests; consumers can mock the trait surface
+- **FHIR canonical model** — single place where FHIR R4 + Thai profile types live; consumers all see the same shapes (per [ADR-006 planned](ADR-006-fhir-r4-canonical.md))
+
+### Negative
+
+- **Workspace complexity** — 7 crates is more ceremony than 1; needs Cargo.toml hygiene + versioning discipline
+- **Cross-crate breaking changes** — bumping core requires bumping all consumers; semver tooling helps but discipline needed
+- **Initial extraction cost** — refactor `extraction.rs` to traits + move to workspace + republish is ~3-5 days (per [underwriter_v3_plan_decisions memory](memory))
+- **Public API responsibility** — once on crates.io, breaking changes require version bump + migration notes; cannot silently refactor
+
+### Risks
+
+- **API design lock-in** — early traits may be wrong; v0.1.x lets us iterate, but a bad v1.0 lockout is painful. Mitigation: don't tag v1.0 until proven across ≥2 consumers (Underwriter + medical chart OCR)
+- **License complexity** — AGPL+Commercial dual licensing for a public crate has nuances around redistribution. Mitigation: clear LICENSE files + FAQ + legal review before v1.0
+- **Performance overhead from trait dispatch** — async trait objects have allocation cost. Mitigation: hot-path benchmarks before lock; consider monomorphization for known-static cases
+
+## Migration Plan
+
+(Maps to Underwriter v3 Phase B per [sprint_tracker_2026_05_17.md](../sprint_tracker_2026_05_17.md))
+
+### B.1 — Refactor in-place (3-4 days, no crate extraction yet)
+
+1. Define traits inside `iris/src/pipeline/` as a new module
+2. Refactor `extraction.rs` to implement traits + remove direct Syn/Mimir/Skuggi calls
+3. Mock implementations for tests
+4. **Regression gate:** all 159 backend tests + 10 E2E pass
+
+### B.2 — Extract to workspace + publish (3-5 days)
+
+1. Create `asgard-doc-pipeline/` workspace at `/Users/mimir/Developer/asgard-doc-pipeline/` (or under Asgard org repo)
+2. Move generic traits + types + adapters from Underwriter into respective crates
+3. Underwriter's `Cargo.toml` adds path dependency on the workspace
+4. **Regression gate:** Underwriter regression suite passes
+5. Build `cargo doc --no-deps` — public API renders cleanly
+6. Add `examples/minimal-pipeline.rs` — must compile and run
+7. Publish v0.1.0 to crates.io
+
+### B.3 — FHIR R4 types (3-5 days, can overlap with B.1/B.2)
+
+Selection list locked in W2.4 task (per sprint tracker). 15 resources:
+
+- Foundation: `Resource`, `DomainResource`, `CodeableConcept`, `Coding`, `Identifier`, `Reference`, `Period`
+- Clinical: `Patient`, `Encounter`, `Observation`, `Condition`, `MedicationRequest`, `MedicationStatement`, `DiagnosticReport`, `DocumentReference`, `Procedure`, `Practitioner`, `Organization`
+- Financial: `Coverage`, `Claim`, `ClaimResponse`, `ExplanationOfBenefit`, `Contract`
+- Workflow: `Appointment`, `Task`
+
+Thai profile: ThaiPatient (citizen_id format, Thai address structure, Thai name parts), ThaiCondition (ICD-10-TM bound), ThaiMedicationRequest (TMT bound).
+
+## Validation
+
+This decision is validated when:
+
+- [ ] `cargo workspace` builds clean
+- [ ] Underwriter 159 backend + 10 E2E tests pass with refactored code
+- [ ] `cargo doc --no-deps` renders core API readably
+- [ ] `examples/minimal-pipeline.rs` runs end-to-end on synthetic input
+- [ ] v0.1.0 published to crates.io with both LICENSE files
+- [ ] Medical chart OCR (W3) can consume the crate without touching Underwriter
+- [ ] No insurance/underwriting types leak into `core` crate (grep audit)
+
+## References
+
+- [feedback_consolidate_overlap_early memory](memory) — origin decision
+- [feedback_asgard_license memory](memory) — AGPL + Commercial dual
+- [underwriter_v3_plan_decisions memory](memory) — Phase B scope
+- [ADR-001](ADR-001-database-choice.md) — DB layer the storage crate adapts
+- [ADR-002](ADR-002-audit-sink-architecture.md) — AuditSink trait the audit-tyr crate hosts
+- [ADR-009](ADR-009-single-tenant-mac-mini-deployment.md) — per-deployment crate, no multi-tenant magic

--- a/docs/decisions/ADR-009-single-tenant-mac-mini-deployment.md
+++ b/docs/decisions/ADR-009-single-tenant-mac-mini-deployment.md
@@ -1,0 +1,118 @@
+# ADR-009: Single-Tenant Per Mac Mini Deployment Model
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Deciders:** paripol@megawiz.co
+**Scope:** Platform-wide (affects Bifrost, Heimdall, Mimir, Underwriter, all future components)
+**Supersedes:** any earlier assumption of SaaS multi-tenant architecture
+
+## Context
+
+Asgard had been planned and discussed in some earlier docs as a multi-tenant SaaS platform — with `tenant_id` as a runtime isolation primitive, per-tenant ACLs, RBAC, cross-tenant routing, etc.
+
+The actual go-to-market model is different and needs to be documented explicitly so future architecture decisions don't drift back toward SaaS assumptions.
+
+**Reality:**
+- Each customer (hospital or insurance company) receives **one dedicated Mac mini** running Asgard on-premise
+- The Mac mini sits in the customer's facility, behind their VPN/Tailscale
+- No data leaves the box unless the customer explicitly configures it (e.g., cloud LLM fallback through Skuggi gate)
+- The customer is the ONLY user-organization on that box
+
+This is on-prem appliance distribution, not SaaS.
+
+## Decision
+
+**Asgard deploys as 1 Mac mini per customer.** Each box runs a single-org installation.
+
+- Technical `tenant_id` is a deployment configuration constant, valued from a fixed enum: `asgard_medical` or `asgard_insurance`
+- Display name follows dual-name convention (like Laminar/Sága): "Asgard Medical" / "Asgard Insurance" in UI, docs, marketing; snake_case in DB/JWT/config
+- **No RBAC** — single org per box means no role separation between users at the platform layer
+- **No multi-tenant routing** — request scoping happens at the box level (physical separation), not in code
+- JWT (Yggdrasil) is for service-to-service auth (e.g., Cloud Run portal → on-prem Mac mini) and proof of box access, not for tenant extraction
+- Per-component audit (Tyr) is local to the box
+
+**The "multi-insurer" pattern within `asgard_insurance` is NOT multi-tenancy.** It means: ONE insurance company customer loads competing product catalogs (Prudential + ThaiLife + Thai Health) onto their own box for product comparison analysis. The `insurer_id` field identifies which insurer issued a product record, not which insurer is logged in.
+
+## Alternatives Considered
+
+### 1. SaaS multi-tenant (rejected, was the implicit prior plan)
+
+- Single Asgard cluster, many customer orgs, RBAC + ACL isolation, cross-tenant search prevented by query-time filtering
+
+**Why rejected:**
+- Healthcare and insurance customers in Thailand strongly prefer on-prem (data sovereignty, PDPA comfort)
+- Cross-org leak risk in SaaS is non-trivial to defend against to clinicians/CISOs
+- Per-customer compute (LLM inference) is hardware-bound; can't time-share GPU across tenants efficiently for clinical-grade latency
+- The Mac mini hardware story is already part of the Asgard pitch
+- Implementation complexity of robust multi-tenant isolation is high; on-prem sidesteps that entirely
+
+### 2. Multi-tenant in a single private cluster (one per customer) (rejected)
+
+- Customer hosts a cluster, Asgard runs as multi-tenant inside it
+
+**Why rejected:**
+- Hospitals don't have the K8s ops capability for this
+- Hardware appliance Mac mini is a simpler sales story
+- The "multi-tenant" code complexity remains without solving any real problem
+
+### 3. Hybrid — appliance + optional SaaS later (deferred, not rejected)
+
+- Same model as #1 but with a future SaaS edition for smaller customers
+
+**Status:** not addressed now. If a SaaS edition is ever pursued, ADR-009 will be revisited. Until then, all design assumes appliance.
+
+## Consequences
+
+### Positive
+
+- **Zero cross-org leak risk by physical separation** — far stronger isolation than any code-level multi-tenant design
+- **PDPA / HIPAA story is simple** — patient data never leaves the box
+- **No RBAC implementation needed** — saves weeks of work and ongoing complexity
+- **Simpler JWT** — proof of access, not tenant routing
+- **Local-only audit** — Tyr instances run per-box, no central SIEM concern (until/unless customer-fleet management becomes a thing)
+- **Predictable performance** — no noisy-neighbor effects; LLM/embedding/OCR resources dedicated to one org
+
+### Negative
+
+- **Operational overhead per customer** — every Mac mini is a separate install, separate update, separate backup story
+- **Update rollout** — N customers = N rollouts; need good CI + runbook discipline
+- **No cross-customer aggregate features** — can't show industry-wide benchmarks (could be added later via opt-in telemetry)
+- **Sales motion** — appliance sales cycle is longer than SaaS signup
+
+### Risks
+
+- **Update drift across customer fleet** — different Mac minis running different Asgard versions. Mitigation: SemVer + customer-managed upgrade window, version-aware rollback runbook.
+- **Customer mismanagement of their box** — patient data on physical hardware in clinic. Mitigation: encrypted disk, automated backups, audit-friendly logs, OS hardening checklist (see Tyr/Muninn workstreams).
+
+## Implications for Active Workstreams
+
+| Workstream | Implication |
+|---|---|
+| Asgard-Underwriter v3 | No RBAC code needed; JWT validates service access; `tenant_id` is a config constant; per-deployment DB |
+| PrimeKG ingestion | Each box has its own PrimeKG copy in its own Mimir Neo4j + Qdrant; refresh propagates via update runbook |
+| Skuggi | Local-first by default already aligns with this model |
+| Tyr | Local box only; no cross-deployment SIEM in v1 |
+| Mega Care portal bridge | Cloud Run portal → that customer's specific Mac mini via Tailscale; not a multi-tenant router |
+| FHIR REST API (planned) | Single-tenant FHIR server per box |
+
+## What This Does NOT Change
+
+- `tenant_id` field still exists in DB rows and audit events — for query convenience, schema portability, and possible future evolution
+- `tenant_id` ∈ {`asgard_medical`, `asgard_insurance`} stays as the controlled vocabulary
+- Within-tenant fields (`hospital_id`, `insurer_id`, ...) exist for product/reference data identification, NOT user/org login routing
+
+## Validation
+
+This decision is validated when:
+
+- [ ] No new code adds per-tenant ACL middleware, RBAC tables, or cross-tenant routing
+- [ ] JWT validation logic remains "is this caller authorized to use this box" (not "which tenant is this caller")
+- [ ] Underwriter v3 Phase A.3 (JWT/Yggdrasil) implements service-auth not tenant extraction
+- [ ] Documentation across the codebase uses "1 box per customer" language consistently
+
+## References
+
+- [feedback_tenant_is_domain_not_org memory](memory)
+- [asgard_insurance_tenant memory](memory)
+- [s2_multi_insurer_architecture memory](memory) — explains the `insurer_id` field for product comparison
+- [MegaCare hosting topology memory](memory) — Cloud Run portal + VPN Case B for box reach

--- a/docs/sprint_tracker_2026_05_17.md
+++ b/docs/sprint_tracker_2026_05_17.md
@@ -1,0 +1,206 @@
+# Sprint Tracker — Asgard Foundation Prep (2026-05-17)
+
+**Created:** 2026-05-17
+**Duration:** 2026-05-17 → 2026-06-12 (Foundation Prep) + Jun 13+ (Sprint 2)
+**Owner:** solo execution
+**Status:** 🟢 ACTIVE
+
+Legend: ⬜ pending · 🟡 in-progress · ✅ done · 🚫 blocked · ❌ cancelled
+
+---
+
+## 🎯 Active execution order
+
+1. Sprint 48 chunking remediation (concurrent with active Sprint 48)
+2. Window 1 ADRs (May 17-18)
+3. PrimeKG Qdrant embedding (when embedding service up)
+4. Window 2 tasks (May 29-Jun 1)
+5. Sprint 2 kickoff (Jun 13+, Phase A.1 shift +1 week)
+
+---
+
+## 🔧 Sprint 48 — Chunking Remediation (~3.5 days)
+
+Pick-up reason: B-48f Qdrant Thai semantic search is deferred; Fix #1 unblocks it.
+
+| ID | Task | Effort | Status | Notes |
+|---|---|---|---|---|
+| C.1 | Thai-aware sentence segmentation in Rust chunking.rs | 0.5d | ✅ | 2026-05-17: Python ingest pipeline not in main (only in v1.0.0-s1-insurance-sprint tag); fixed at Rust `services/chunking.rs::split_by_sentences` instead. Added Thai paiyannoi (ฯ), newline, and whitespace-after-Thai as boundaries. 5/5 integration tests pass at `tests/chunking_thai.rs`. mimir-core-ai 0.2.0 → 0.2.1. **Full HTTP PyThaiNLP wire deferred** — requires async refactor of sync split_by_sentences API. Unblocks B-48f Qdrant Thai semantic search. |
+| C.2 | Replace token estimator `chars/4` with proper tokenizer | 0.5d | ✅ | 2026-05-17: PR [#300](https://github.com/MegaWiz-Dev-Team/Mimir/pull/300). Used HuggingFace `tokenizers` crate (Rust-First), lazy-loaded via `BGE_M3_TOKENIZER_PATH` env, graceful fallback to chars/4. Independent of #299. mimir-core-ai 0.2.0 → 0.2.2. 3/3 integration tests pass on both env-set and env-unset paths. |
+| C.3 | Insurance chunk size default 300 → 800 tokens | 0.25d | ⬜ | After C.5 benchmark confirms; touch: `phase1_extraction.py:19-20`, `phase1_extraction_s2.py` |
+| C.4 | Port Rust recursive chunker logic into Python pipeline | 1d | ⬜ | Or call Rust via API; preserves markdown hierarchy |
+| C.5 | Benchmark matrix: chunk_size × overlap × language on Hit Rate@3 | 1d | ✅ | 2026-05-18 PR [#301](https://github.com/MegaWiz-Dev-Team/Mimir/pull/301). Sprint 48 v0 18 queries: baseline semantic-only **61.1%** vs full cascade **100.0%** (+38.9pp). Cascade matches production icd10.rs path. Quick wins 1+2+3 already in main; this PR is proof-of-correctness benchmark. **Bonus:** restored `icd10_codes` table (15,376 rows from Qdrant payloads — was empty after Sprint 51e rotation). Full chunk-size matrix (size×overlap×lang) NOT applicable to icd10-th (single-row chunks); defer to pubmed-abstracts/insurance corpus sprint. |
+| C.6 | ADR — Chunking strategy (post-benchmark decision) | 0.25d | ⬜ | Commit if 800 > 300 by ≥5pp Hit Rate@3 |
+
+**Decision gate (C.5):** ≥5pp improvement → switch default. Else stay 300, document why.
+
+---
+
+## 📅 Window 1 — May 17-18 (2 days, NOT blocked by S1)
+
+| ID | Task | Effort | Status | Notes |
+|---|---|---|---|---|
+| W1.1 | Verify PrimeKG Qdrant state | 0.5d | ✅ | Confirmed: code exists ([routes/admin_knowledge.rs:152,214](Mimir/ro-ai-bridge/src/routes/admin_knowledge.rs)) but never RUN. Collection `primekg-entities` (1024-dim) ready to populate |
+| W1.2 | Read MegaCare TriParty PoC TechBrief | — | ❌ | Out of scope per user 2026-05-17 |
+| W1.3 | Read Sprint 48 progress doc | 0.5d | ✅ | Done — 4/10 backlog shipped, B-48f deferred (embedding service down), B-48a license pending |
+| W1.4 | Read Multi-Agent Architecture Plan | 0.5d | ⬜ | P1, optional |
+| W1.5 | ADR-001 DB choice (MariaDB) | 0.25d | ✅ | [ADR-001](decisions/ADR-001-database-choice.md) — 2026-05-17 |
+| W1.6 | ADR-002 Audit sink architecture | 0.25d | ✅ | [ADR-002](decisions/ADR-002-audit-sink-architecture.md) — 2026-05-17 |
+| W1.7 | ADR-003 Trait-based extraction + shared crate boundary | 0.5d | ✅ | [ADR-003](decisions/ADR-003-shared-doc-pipeline-crate.md) — 2026-05-17 |
+| W1.8 | ADR-009 Single-tenant per Mac mini deployment model | 0.25d | ✅ | [ADR-009](decisions/ADR-009-single-tenant-mac-mini-deployment.md) — 2026-05-17 |
+
+---
+
+## ⚡ PrimeKG Qdrant Embedding (~30 min when embedding service up)
+
+| ID | Task | Effort | Status | Notes |
+|---|---|---|---|---|
+| P.1 | Verify embedding service `host.docker.internal:8001` status | 0.1d | 🚫 | Confirmed DOWN 2026-05-17. localhost:8001 not responding |
+| P.1b | Verify Qdrant access path | 0.1d | ✅ | Qdrant pod Running in `asgard-infra`, ClusterIP only → needs port-forward or in-cluster call |
+| P.2 | Start embedding service on host (BGE-M3 via FastEmbed or Ollama nomic-embed-text) | 0.25d | 🚫 | NEEDS USER: manual start preferred or document the start procedure |
+| P.3 | Trigger PrimeKG node embedding → `primekg-entities` collection | 0.25d | 🚫 | Blocked by P.2 |
+| P.4 | Validate: count = ~129K, sample retrieval query works | 0.1d | 🚫 | Blocked by P.3 |
+
+---
+
+## 📆 Window 2 — May 29-Jun 1 (4 days, between S1 phases)
+
+| ID | Task | Effort | Status | Notes |
+|---|---|---|---|---|
+| W2.1 | Medical retrieval benchmark queries (50-100 TH/EN) | 1d | ✅ | 2026-05-18 M1 dataset shipped — 75 queries (14 categories, TH 25 / EN 48 / mixed 2; easy 19 / medium 36 / hard 20). Registered in eval_benchmark_datasets as `m1_medical_retrieval_v1` (id `10659f35-…`). Includes sleep-specific subset for Mega Care + negation/distractor queries. |
+| W2.2 | Send chart sample request to Mega Care | 0.5d | ⬜ | 20-50 de-identified samples + chain of custody |
+| W2.3 | TMT/TPC license inquiry to MoPH | 0.5d | ⬜ | Piggy-back ICD-10-TM follow-up |
+| W2.4 | FHIR R4 resource selection list (~15 + Thai profile) | 1d | ✅ | 2026-05-18 spec doc at [architecture/fhir_r4_resource_selection.md](architecture/fhir_r4_resource_selection.md). 15 resources locked: Patient/Encounter/Observation/Condition/MedicationRequest/MedicationStatement/Procedure/DiagnosticReport/AllergyIntolerance/DocumentReference + Coverage/Claim/ClaimResponse + Practitioner/Organization. Thai profile constraints for 7 resources. Hand-rolled types recommended over `fhirbolt`. 5 open questions parked for ADR-006. |
+| W2.5 | 6 Hermodr MCP tool schemas (JSON spec) | 0.5d | ✅ | 2026-05-18 Hermodr PR #5 MERGED. 6 PrimeKG graph-native tools shipped: primekg_lookup_entity, _neighbors, _drug_interactions, _disease_drugs, _symptom_to_disease, _path. 57/57 tests passing. Mimir backend endpoint impl is separate follow-on. |
+| W2.6 | ADR-006 FHIR R4 + Thai coding canonical | 0.5d | ⬜ | |
+| W2.7 | Verify MoPH ICD-10-TM 2017 response (due ~May 21) | 0.25d | ⬜ | Decision tree per license-request doc |
+| W2.1b | **Synthetic Thai applicants Faker generator** | 2d | ✅ | 2026-05-18 shipped. Path: `Mimir/scripts/synthetic_thai_applicants/`. 7 modules + 19 tests. CLI: `python -m synthetic_thai_applicants --applicants 1000 --claims 500 --seed 42 --output ./out --pdf`. Reproducible seed, Luhn-valid Thai citizen IDs, correlated fraud injection (5 rules), Thai-font PDF medical certificates. Smoke test 50/30 = 17% fraud rate. Delivers I1/I2/X1/M3 dataset inputs. |
+| W2.1c | **Dataset inventory plan registration in eval_benchmark_datasets** | 0.5d | 🟡 | 2026-05-18 I1 + I2 registered (1000 applicants + 500 claims, seed=42). Idempotent upsert script at `scripts/register_eval_datasets_i1_i2.py`. Canonical data committed at `tests/eval_datasets/i1/v1.0/`. M1/M4/M8/I5 deferred to separate PRs (each needs its own ground-truth labeling). |
+
+---
+
+## 🚪 Window 3 — Jun 12 (Sprint gate)
+
+| ID | Task | Effort | Status | Notes |
+|---|---|---|---|---|
+| W3.1 | Sprint review + Sprint 2 lock | 0.25d | ⬜ | Update plan based on Window 1-2 results |
+| W3.2 | S1 RefGraph go/no-go (external) | — | ⬜ | Per S1 plan, gate day |
+
+---
+
+## 🚀 Sprint 2 Preview (Jun 13+, NOT committed yet)
+
+**Phase A.1 shifted +1 week → starts Jun 20** (was Jun 13)
+**Total Sprint 2 effort:** ~5-6 weeks (up from 4) after AWS sample learnings absorbed into Phase C/D
+
+### Phase A — Foundation (3 weeks)
+
+| ID | Task | Effort | Notes |
+|---|---|---|---|
+| S2.A.1 | Underwriter v3 MariaDB persistence | 5-7d | Per ADR-001; 10 tables incl `chat_sessions`/`audit_events` |
+| S2.A.2 | Tyr audit integration | 3-4d | Per ADR-002; LocalDbSink + Wazuh stub + hash chain |
+| S2.A.3 | JWT/Yggdrasil auth | 3-4d | Per ADR-009; service-to-service auth, not tenant routing |
+
+### Phase B — Architecture refactor (1-2 weeks)
+
+| ID | Task | Effort | Notes |
+|---|---|---|---|
+| S2.B.1 | Refactor `extraction.rs` → trait-based | 3-4d | Per ADR-003 |
+| S2.B.2 | Extract `asgard-doc-pipeline` workspace + publish v0.1.0 | 3-5d | Per ADR-003; crates.io public AGPL+Commercial |
+| S2.B.3 | FHIR R4 types (~15 resources) + Thai profile | 3-5d | Per ADR-006 (pending); ICD-10-TM/TMT/TPC bindings |
+
+### Phase C — Production hardening + MCP tool catalog (~3 weeks)
+
+**EXPANDED from AWS sample analysis** — added C.5-C.9 (fraud detection + analytics + MCP wrap)
+
+| ID | Task | Effort | Notes |
+|---|---|---|---|
+| S2.C.1 | Multi-insurer product comparison (Prudential/ThaiLife/Thai Health) | 5-6d | S2 architecture, dedup >0.95 |
+| S2.C.2 | HITL queue production (SLA, assignment, escalation) | 3d | Reuse from Phase A.1 schema |
+| S2.C.3 | Observability (prometheus + OTel + JSON logs) | 3d | Per ADR-005 (pending) |
+| S2.C.4 | PDF export depth | 3d | Keep `printpdf`; add ICD-10/timeline/HITL notes |
+| **S2.C.5** | **Fraud detection heuristic engine** | 2d | NEW from AWS sample. Correlated patterns: short-policy + high-amount, repeat-claimant, status-investigating |
+| **S2.C.5b** | **`underwriter.fraud_detect(claim_id)` MCP tool** | 0.5d | NEW. Eir reasoning explanation layer |
+| **S2.C.6** | **Portfolio analytics aggregation queries** | 1.5d | NEW. Risk distribution, claims trends, fraud trend, throughput |
+| **S2.C.6b** | **`underwriter.portfolio_analytics(filters)` MCP tool** | 0.5d | NEW |
+| **S2.C.7** | **Wrap existing workflows as 5 MCP tools** | 1.5d | NEW. health/risk_assess/medical_analyze/decision/case_create |
+| **S2.C.8** | **Register 8 tools in Hermodr + Eir allowlist** | 0.5d | NEW |
+| **S2.C.9** | **Tool invocation audit (every call → audit_events)** | 0.5d | NEW; uses Phase A.2 audit pattern |
+
+### Phase D — Polish + UX adoptions (~2 weeks)
+
+**EXPANDED from AWS sample analysis** — added D.5-D.8 (reasoning UI + chat panel + tool viz + deep mode)
+
+| ID | Task | Effort | Notes |
+|---|---|---|---|
+| S2.D.1 | Frontend test coverage (4/12 → ≥10/12) | 2-3d | |
+| S2.D.2 | Benchmarks (k6 load test, SLO definition) | 2d | |
+| S2.D.3 | Server-mode Docker | 2d | |
+| S2.D.4 | ADR backfill | 1d | ADR-004/005/006/007/008/010 |
+| **S2.D.5** | **Reasoning trace UI** (collapsible per-agent in Assessment + ExtractionReview) | 2d | NEW. Quick Suite-inspired explainability |
+| **S2.D.5b** | **Backend: per_agent_reasoning field in risk response** | 0.5d | NEW. Depends C.7 |
+| **S2.D.6** | **Case-scoped chat panel** — design + SSE protocol | 1d | NEW. Per [cloudflare_timeout_sse memory](memory) — SSE not WebSocket |
+| **S2.D.6b** | **Backend: ChatSession + multi-turn Eir-router** | 2d | NEW |
+| **S2.D.6c** | **Frontend `<CaseChatPanel/>` component** | 1.5d | NEW. Streaming + tool invocation visible |
+| **S2.D.7** | **Tool invocation visualization in HITLQueue** | 1.5d | NEW. Reads audit_events |
+| **S2.D.8** | **Deep mode toggle** (high reasoning effort) | 1d | NEW. Maps to Heimdall maxReasoningEffort |
+
+### Carryover from Sprint 48
+
+| ID | Task | Effort | Notes |
+|---|---|---|---|
+| S2.W2.1 | PrimeKG benchmark + runbook | 3-5d | Remaining W2 Phase 1 tasks |
+| S2.CO.1 | Chunking remediation rollout (if Sprint 48 unfinished) | — | Carryover |
+
+---
+
+## 📝 Decision Log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-17 | DB = MariaDB first (not Postgres-everywhere) | Bifrost stack stable, blast radius too high |
+| 2026-05-17 | Audit sink = LocalDbSink + Wazuh stub | Local first, Wazuh ready for when Tyr scales up |
+| 2026-05-17 | crates.io public for shared crate | AGPL+Commercial dual license; open-core moat |
+| 2026-05-17 | Keep `printpdf` | Stability over polish (typst nicer but switch cost too high) |
+| 2026-05-17 | Insurers: Prudential, ThaiLife, Thai Health | NOT AXA; user correction |
+| 2026-05-17 | 1 Mac mini per customer, on-prem single-tenant | No RBAC, tenant_id is deployment config |
+| 2026-05-17 | Embedding runtime = candle + Metal recommended | Rust-First, no architecture split (vs MLX which needs host service split) |
+| 2026-05-17 | FHIR R4 canonical + Thai coding (ICD-10-TM/TMT/TPC) | Cross-domain interop free if both sides speak FHIR |
+| 2026-05-17 | Display names "Asgard Medical" / "Asgard Insurance" | Tech tenant_id stays snake_case; dual-name like Laminar/Sága |
+| 2026-05-17 | Chunking remediation → Sprint 48 (not Sprint 2) | Unblocks B-48f Qdrant Thai search |
+| 2026-05-17 | Phase A.1 shift +1 week (Jun 13 → Jun 20) | Chunking remediation absorbs 5 days |
+| 2026-05-17 | AWS sample analysis → adopt Faker, 6 MCP tools (+2 new), 4 UX patterns | Phase C adds fraud + analytics + MCP wrap (+5d); Phase D adds reasoning trace + chat + tool viz + deep mode (+8d); Sprint 2 grows 4→5-6 weeks |
+| 2026-05-17 | Adopt 8-tool MCP catalog over Hermodr (mirror AWS pattern) | health/risk/medical/fraud/decision/analytics/case_create/hitl_status. External-facing for future portal bridges |
+| 2026-05-17 | Case-scoped chat uses SSE (not WebSocket) | Per `cloudflare_timeout_sse` memory — proven pattern, CF-friendly |
+| 2026-05-17 | Faker generator output includes synthetic PDFs (not just JSON) | Asgard pipeline tests OCR; AWS sample is JSON-only |
+| 2026-05-17 | Faker fraud_indicators must be correlated (not random) | AWS sample uses pure random which doesn't train/test fraud detection meaningfully |
+| 2026-05-17 | Heimdall #10 + Mimir #294/#295/#297/#298 merged. Mimir tagged v1.4.0; Heimdall tagged v0.7.0 (NOT v0.6.0 due to existing legacy tag conflict from Hotswap fix May 5). Stacked-merge via #298 brought entire JWT chain. | Backend SSO release ships locked. Production deploy unblocks via [deploy runbook in commit 72d9483](https://github.com/MegaWiz-Dev-Team/Mimir/commit/72d9483) |
+
+---
+
+## 🚩 Risks Active
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Embedding service down → PrimeKG Qdrant + B-48f blocked | High (was down 2026-05-07) | Medium | P.1/P.2 priority; FastEmbed local fallback |
+| S1 spillover → Window 2 days lost | Medium | High | Cut P1 (W2.6) first |
+| MoPH no-response by May 21 | Medium | Medium | International ICD-10 only path |
+| Mega Care chart samples slow | High | High | Send request immediately on May 29 |
+| Chunking benchmark shows 300 already optimal | Low | Low | Document + close ticket |
+| Sprint 2 over-scoped at 5-6 weeks | Medium | Medium | Phase D5-D8 (chat + reasoning UI) are cuttable to Sprint 3 if Phase C delays |
+| Faker generator coupling to ICD-10-TM table breaks if schema changes | Low | Low | Pin schema version + test isolation |
+| AWS sample evolves and adds patterns worth tracking | Medium | Low | Re-audit aws-samples/sample-quicksuite-chatagent-insurance-underwriting quarterly |
+
+---
+
+## 📎 References
+
+- [feedback_tenant_is_domain_not_org](memory)
+- [underwriter_v3_plan_decisions](memory)
+- [mimir_chunking_audit](memory)
+- [PrimeKG data report](docs/reference/PRIMEKG_DATA_REPORT.md)
+- [Sprint 48 progress](Mimir/docs/03_implementation_plans/sprint48_progress_2026-05-07.md)
+- [ICD-10-TM license request](Asgard/legal/2026-05-07_MoPH_ICD-10-TM_License_Request.md)
+- AWS sample (competitor analysis): https://github.com/aws-samples/sample-quicksuite-chatagent-insurance-underwriting
+- [Solution architecture — Agent/MCP/RAG/Graph/PageIndex/RefGraph](architecture/agent_rag_graph_solution_architecture.md)
+- [Evaluation dataset inventory plan 2026-05-17](../../Mimir/docs/04_evaluation_and_testing/04_10_dataset_inventory_plan_2026-05-17.md)


### PR DESCRIPTION
## Summary

Two commits in one PR:

1. **W2.4 FHIR R4 resource selection spec** (Sprint 2 W2.4 deliverable) — locks the 15 canonical FHIR resources for the asgard-doc-pipeline shared crate
2. **Backfill ADRs + solution architecture** from earlier in this same session that were drafted but never committed

## #1 — FHIR R4 selection (W2.4)

[\`docs/architecture/fhir_r4_resource_selection.md\`](../blob/main/docs/architecture/fhir_r4_resource_selection.md)

15 resources locked:

**Clinical (10):** Patient (ThaiPatient profile), Encounter, Observation, Condition (ICD-10-TM bound), MedicationRequest (TMT bound), MedicationStatement, Procedure (TPC bound), DiagnosticReport, AllergyIntolerance, DocumentReference

**Insurance (3):** Coverage, Claim, ClaimResponse

**Workflow / participants (2):** Practitioner, Organization

Plus Bundle (implicit) + 12 foundational datatypes (Identifier, CodeableConcept, Coding, Reference, HumanName, Address, ContactPoint, Period, Quantity, Money, Range, Annotation).

### Thai profile bindings

| Resource | Constraint |
|---|---|
| Patient | Thai citizen ID identifier required; Thai-script name MUST; address fields mapped to ตำบล/อำเภอ/จังหวัด |
| Condition | ICD-10-TM coding required (anamai-moph-2010 or successor) |
| MedicationRequest | TMT coding recommended; Thai dosage_instruction.text |
| Procedure | TPC coding recommended |
| Coverage | payor MUST be a registered Thai insurer (OIC list) |
| Money | default currency THB |

### Implementation path

Hand-rolled Rust types over \`fhirbolt\` codegen. Reasons:
- Full control over Thai profile typing (compile-time, not runtime check)
- Only 15 resources — codegen overhead not worth it
- Smaller compile times + smaller binary
- If external EHR integration ever needs deep FHIR R4 (~150 resources), introduce \`fhirbolt\` as a **separate adapter crate** at that boundary; don't pollute core

### Out of scope (v1)

Goal, CarePlan, Schedule, Slot, Appointment, Immunization, FamilyMemberHistory, Specimen, ImagingStudy, Communication, CommunicationRequest, Task, Group, EpisodeOfCare, ExplanationOfBenefit, Contract, PaymentNotice, PaymentReconciliation — add to v2 only when a real consumer needs them.

### 5 open questions parked for ADR-006

1. Bundle.entry typing — closed enum vs Box<dyn Resource>
2. Resource versioning — meta.versionId tracked or audit-via-Tyr
3. Auto-generated JSON Schema for external consumers via \`schemars\`
4. Loose vs strict parsing on external FHIR ingest
5. i18n / locale fields — plain string vs FHIR _language extension

## #2 — Backfill ADRs + solution architecture

These were drafted Window-1 of this session, referenced by multiple subsequent PRs, but never made it into a commit. Catch-up landing now:

| File | Decision |
|---|---|
| \`docs/decisions/ADR-001-database-choice.md\` | MariaDB first; Postgres deferred per component |
| \`docs/decisions/ADR-002-audit-sink-architecture.md\` | AuditSink trait + LocalDbSink + Wazuh stub + hash chain; 13 critical events |
| \`docs/decisions/ADR-003-shared-doc-pipeline-crate.md\` | Trait boundary + 7-crate workspace + crates.io AGPL+Commercial public |
| \`docs/decisions/ADR-009-single-tenant-mac-mini-deployment.md\` | Asgard NOT SaaS; 100 customers = 100 boxes; no RBAC; tenant_id = config not isolation |
| \`docs/architecture/agent_rag_graph_solution_architecture.md\` | 4 knowledge reps (Vector/PrimeKG/RefGraph/PageIndex), per-tenant component allocation, 35-tool catalog, 5-phase rollout |

These were referenced by:
- Sprint 48 chunking PRs (#299/#300/#301)
- Backend SSO PRs (Mimir #294-298, Heimdall #10)
- W2.5 Hermodr PrimeKG tools (#5)

Now those references resolve.

## Discipline note

For future sprints: **commit ADRs the moment the decision is locked**, not at sprint end. ADRs feel like "just docs" when there's code to ship, but the downstream PRs depend on them landing in time. This session shipped 10 PRs in front of 4 unmerged ADRs — close call.

## Test plan

- [x] All 4 ADRs render cleanly in GitHub markdown preview
- [x] Solution architecture doc cross-references resolve
- [x] FHIR spec covers 15 resources + datatypes + Thai bindings + out-of-scope
- [x] Sprint tracker W2.4 marked complete with link to spec
- [ ] When ADR-006 lands, FHIR open questions get answered
- [ ] When Phase B.3 implementation lands, validate spec against implementation

## Refs

- Sprint tracker: \`Asgard/docs/sprint_tracker_2026_05_17.md\` (W2.4)
- Cross-referenced by: Sprint 48 chunking + Backend SSO + W2.5 PrimeKG tools
- Future ADR-006 (FHIR canonical) will lock open questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)