### PR TITLE
ci(integ): promote syn-api scenarios from advisory to gate

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -79,13 +79,13 @@ jobs:
 
       - name: Run Forseti YAML scenarios (syn-api)
         id: forseti_scenarios_syn
-        continue-on-error: true
         env:
           FORSETI_REPO: ${{ env.ASGARD_DEV_ROOT }}/Forseti
-        # Sprint 50 — Syn S1 smoke tests (10 scenarios, mostly GET).
-        # Advisory until Sprint 50 SQL migrations land on the live cluster
-        # — the /policy + /documents routes currently 500 without the
-        # ocr_documents table + tenant_configs Sprint 50 columns.
+        # Sprint 50 → Sprint 51 — Syn S1 smoke tests (10 scenarios, mostly GET).
+        # Promoted from advisory to gate 2026-05-19: Sprint 50 SQL migrations
+        # landed on the live cluster (ocr_documents table + tenant_configs
+        # Sprint 50 columns) and the last 5 consecutive Integration Tests
+        # runs reported syn-api=success. /policy + /documents are stable.
         run: |
           set -o pipefail
           cd "$FORSETI_REPO"
@@ -102,7 +102,7 @@ jobs:
             echo "| Suite | Outcome |"
             echo "|:--|:--|"
             echo "| bifrost-api (gate) | ${{ steps.forseti_scenarios.outcome }} |"
-            echo "| syn-api (advisory) | ${{ steps.forseti_scenarios_syn.outcome }} |"
+            echo "| syn-api (gate) | ${{ steps.forseti_scenarios_syn.outcome }} |"
             echo ""
             echo "| Service | Health |"
             echo "|:--|:--|"


### PR DESCRIPTION
## Summary

Sprint 51 P0 finish. Drops \`continue-on-error: true\` from the **syn-api** scenarios step in [.github/workflows/integration-test.yml](.github/workflows/integration-test.yml#L80-L92) so future deploys are actually gated on Syn HTTP-level health.

## Why now

The original advisory comment said: *"Advisory until Sprint 50 SQL migrations land on the live cluster — the /policy + /documents routes currently 500 without the ocr_documents table + tenant_configs Sprint 50 columns."*

Status check (2026-05-19):
- **Sprint 50 migrations**: landed on the live cluster.
- **Recent runs (workflow=Integration Tests)**: last 5 consecutive successful runs (workflow_dispatch + workflow_run, May 12 → May 13) report \`syn-api=success\`.
- **Failure cluster**: the only failures on file are May 12 03:49 → 09:35, which preceded the migrations landing.

This is short of the 2-week clean-green window originally specified for the gate promotion (~7 days observed), so it is a judgment call. If reviewer prefers to hold, queue this PR for merge ~2026-05-26 instead.

## What changes

```diff
-        continue-on-error: true
         env:
           FORSETI_REPO: ${{ env.ASGARD_DEV_ROOT }}/Forseti
-        # Sprint 50 — Syn S1 smoke tests (10 scenarios, mostly GET).
-        # Advisory until Sprint 50 SQL migrations land on the live cluster
-        # — the /policy + /documents routes currently 500 without the
-        # ocr_documents table + tenant_configs Sprint 50 columns.
+        # Sprint 50 → Sprint 51 — Syn S1 smoke tests (10 scenarios, mostly GET).
+        # Promoted from advisory to gate 2026-05-19: Sprint 50 SQL migrations
+        # landed on the live cluster (ocr_documents table + tenant_configs
+        # Sprint 50 columns) and the last 5 consecutive Integration Tests
+        # runs reported syn-api=success. /policy + /documents are stable.

-            echo "| syn-api (advisory) | ${{ steps.forseti_scenarios_syn.outcome }} |"
+            echo "| syn-api (gate) | ${{ steps.forseti_scenarios_syn.outcome }} |"
```

## Test plan

- [ ] Reviewer agrees 5 consecutive green is enough signal (vs. waiting for the full 2 weeks).
- [ ] After merge, watch the next Deploy → Integration Tests chain; if \`syn-api\` flakes, revert this PR.
- [ ] Confirm the GitHub Step Summary shows \`syn-api (gate)\` instead of \`syn-api (advisory)\`.

Refs: Sprint 51 P0 carryover (Syn gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)