### PR TITLE
ops: deploy-all.sh + QUICK_START + CHECKLIST + RECOVERY runbooks (supersedes part of #64)

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,221 @@
+# K8s Deployment Checklist
+
+**Purpose:** Prevent configuration errors like INC-2026-05-17-001 (Mimir 503 due to missing MYSQL_USER env var)
+
+**When to use:** Before every `kubectl apply` or `./scripts/deploy-all.sh`
+
+---
+
+## Pre-Deployment Checklist
+
+### 1. Validate Manifests
+```bash
+./scripts/validate-k8s-before-deploy.sh
+```
+
+**What it checks:**
+- ✅ All required environment variables present (MYSQL_USER, MYSQL_PASSWORD, etc.)
+- ✅ Image pull policies correct for K3s (imagePullPolicy: Never)
+- ✅ PersistentVolumeClaims exist
+- ✅ Required secrets configured
+- ✅ Health checks defined
+
+**If it fails:** Fix errors before proceeding to step 2
+
+---
+
+### 2. Review Manifest Diff
+```bash
+kubectl diff -f k8s/asgard
+kubectl diff -f k8s/asgard-infra
+```
+
+**Look for:**
+- Unexpected changes to critical configs
+- Missing or removed volumes
+- Changed resource limits
+- Removed environment variables
+
+**If unexpected:** Revert and investigate
+
+---
+
+### 3. Check Current Pod Status
+```bash
+kubectl get pods -A
+kubectl get pvc -A
+```
+
+**Ensure:**
+- No pods in CrashLoopBackOff
+- All PVCs are Bound (not Pending)
+- No stale pods from previous deployments
+
+---
+
+### 4. Apply Changes
+```bash
+# Dry-run first
+kubectl apply -f k8s/asgard --dry-run=client
+
+# If OK, apply for real
+kubectl apply -f k8s/asgard
+kubectl apply -f k8s/asgard-infra
+```
+
+---
+
+### 5. Verify Deployment
+
+```bash
+# Wait for pods to be ready (2-3 min typical)
+kubectl wait --for=condition=ready pod -l app=mimir-api -n asgard --timeout=300s
+kubectl wait --for=condition=ready pod -l app=mariadb -n asgard-infra --timeout=300s
+
+# Check all pods are running
+kubectl get pods -A | grep -E "Running|Ready"
+
+# Check logs for errors
+kubectl logs -n asgard -l app=mimir-api --tail=20
+kubectl logs -n asgard-infra -l app=mariadb --tail=20
+```
+
+**Expected:**
+- Mimir API: `listening on 0.0.0.0:8080`
+- MariaDB: `ready for connections`
+- No ERROR or panic messages
+
+---
+
+## Required Environment Variables
+
+### MariaDB (`k8s/asgard-infra/mariadb-deployment.yaml`)
+
+| Variable | Required? | Default | Notes |
+|----------|-----------|---------|-------|
+| MYSQL_ROOT_PASSWORD | ✅ YES | — | Root user password |
+| MYSQL_DATABASE | ✅ YES | — | Initial database name (should be `mimir`) |
+| MYSQL_USER | ✅ YES | — | App user name (should be `mimir`) |
+| MYSQL_PASSWORD | ✅ YES | — | App user password |
+
+**If ANY are missing:**
+- MariaDB will start with no users
+- Mimir will crash with: `ERROR 1045 (28000): Access denied for user 'mimir'`
+- Service down until fixed
+
+### Mimir (`k8s/asgard/mimir-api-deployment.yaml`)
+
+| Variable | Required? | Source | Notes |
+|----------|-----------|--------|-------|
+| DATABASE_URL | ✅ YES | Secret | `mysql://mimir:PASSWORD@mariadb:3306/mimir` |
+| PORT | Optional | — | Default: 8080 |
+| RUST_LOG | Optional | — | Default: info |
+
+---
+
+## Common Issues & Solutions
+
+### Issue: "Access denied for user 'mimir'"
+```
+ERROR 1045 (28000): Access denied for user 'mimir'@'192.168.194.X' (using password: YES)
+```
+
+**Cause:** MYSQL_USER or MYSQL_PASSWORD env var missing/wrong
+
+**Fix:**
+```bash
+# Check what's set
+kubectl get deployment mariadb -n asgard-infra -o yaml | grep -A 10 "env:"
+
+# If missing, add them
+kubectl set env deployment/mariadb -n asgard-infra \
+  MYSQL_USER=mimir \
+  MYSQL_PASSWORD=<from-secret>
+
+# Restart
+kubectl rollout restart deployment/mariadb -n asgard-infra
+```
+
+---
+
+### Issue: Pod stuck in CrashLoopBackOff
+```
+mimir-api-XXXXX   0/1     CrashLoopBackOff   5 (2m ago)
+```
+
+**Debug:**
+```bash
+# Check pod logs
+kubectl logs mimir-api-XXXXX -n asgard --tail=50
+
+# Common causes:
+# - Database not ready (check MariaDB)
+# - Database user/password wrong (see above)
+# - Missing env vars (run validation script)
+# - Image pull failed (check imagePullPolicy)
+```
+
+---
+
+### Issue: PVC stuck in Pending
+```
+mariadb-data   Pending   — 5m
+```
+
+**Cause:** Storage not allocated, or node doesn't have capacity
+
+**Check:**
+```bash
+kubectl describe pvc mariadb-data -n asgard-infra
+# Look for "Events:" section with error messages
+
+# Typical fix:
+kubectl delete pvc mariadb-data -n asgard-infra
+# (will be recreated with fresh storage)
+```
+
+---
+
+## Health Check Endpoints
+
+After deployment, verify these respond:
+
+```bash
+# Mimir health
+curl -v http://mimir.asgard.svc:8080/healthz
+# Expected: HTTP 200 OK
+
+# MariaDB
+kubectl exec -n asgard-infra mariadb-XXXXX -- \
+  mariadb -u mimir -p<PASSWORD> -e "SELECT 1;"
+# Expected: 1 row returned
+```
+
+---
+
+## Rollback (If Something Goes Wrong)
+
+```bash
+# Revert to previous K8s state
+kubectl rollout undo deployment/mimir-api -n asgard
+kubectl rollout undo deployment/mariadb -n asgard-infra
+
+# Check status
+kubectl rollout status deployment/mimir-api -n asgard
+```
+
+---
+
+## Incident History
+
+- **INC-2026-05-17-001:** Missing MYSQL_USER/MYSQL_PASSWORD → 4h 6m outage
+  - **Prevention:** This checklist + validation script
+
+---
+
+## Questions?
+
+See:
+- [Incident report](./docs/incidents/2026-05-17-mimir-503/incident-report.md) — Full technical analysis
+- [Postmortem](./docs/incidents/2026-05-17-mimir-503/postmortem.md) — Team learning
+- `./scripts/validate-k8s-before-deploy.sh` — Automated validation

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,119 @@
+# 🚀 Asgard Platform — Quick Start
+
+## Deploy Everything (60 seconds)
+
+```bash
+cd /Users/mimir/Developer/Asgard
+./scripts/deploy-all.sh
+```
+
+**First run:** 5-15 min (Docker builds, K8s rollouts)  
+**Subsequent runs:** 2-5 min (image pull, restart)
+
+---
+
+## Deploy Only What You Need
+
+### K8s Only (Bifrost, Eir, Mimir, Odin, Hermodr, etc.)
+```bash
+SKIP_HEIMDALL=true ./scripts/deploy-all.sh
+```
+
+### Heimdall Only (MLX Gateway + LLM Services)
+```bash
+SKIP_K8S=true ./scripts/deploy-all.sh
+```
+
+---
+
+## Quick Verification
+
+### K8s Services
+```bash
+kubectl get pods -n asgard -w
+kubectl logs -n asgard -l app=bifrost --tail=50
+```
+
+### Heimdall Services
+```bash
+cd /Users/mimir/Developer/Heimdall
+./scripts/manage-heimdall.sh status
+```
+
+### Test Endpoints
+```bash
+# Bifrost health
+curl http://bifrost:8000/health
+
+# Eir chat
+curl http://eir-gateway:3000/chat.html
+
+# Heimdall gateway
+curl http://localhost:8080/health
+```
+
+---
+
+## Common Issues
+
+### K8s Pods Stuck in Pending
+```bash
+# Check resource availability
+kubectl describe node
+
+# Check pod events
+kubectl describe pod <pod-name> -n asgard
+```
+
+### Image Pull Errors
+```bash
+# Force re-pull with latest digest
+kubectl rollout restart deployment/bifrost -n asgard
+```
+
+### Heimdall Services Not Starting
+```bash
+# Check logs
+tail -f ~/.asgard-logs/heimdall-gateway.log
+tail -f ~/.asgard-logs/heimdall-mlx.log
+
+# Restart
+./scripts/manage-heimdall.sh restart
+```
+
+---
+
+## Architecture Overview
+
+```
+OpenEMR
+  ↓
+Eir Gateway (3000)
+  ├─→ Syn (OCR)
+  ├─→ Mimir (RAG storage)
+  ├─→ Bifrost (agent orchestration)
+  │   └─→ Heimdall Gateway (8080)
+  │       ├─→ MLX (8081)
+  │       ├─→ VLM q4 (8082)
+  │       └─→ VLM q8 (8083)
+  └─→ OpenEMR FHIR API
+
+Tyr (Security)
+  ├─→ Wazuh (threat detection)
+  └─→ Muninn (auto-response)
+```
+
+---
+
+## Next Steps
+
+- **Full setup:** See `DEPLOYMENT.md`
+- **Troubleshooting:** See `/Users/mimir/Developer/TROUBLESHOOTING_GUIDE.md`
+- **Test suite:** See `/Users/mimir/Developer/UI_TESTING_GUIDE.md`
+
+---
+
+**Questions?** Check DEPLOYMENT.md or run:
+```bash
+./scripts/deploy-all.sh --help
+```

--- a/RECOVERY_RUNBOOKS.md
+++ b/RECOVERY_RUNBOOKS.md
@@ -1,0 +1,295 @@
+# Recovery Runbooks — Asgard K8s
+
+**Quick fixes for common Asgard incidents**
+
+Use these when something goes wrong. Always run deployment validation after fixes.
+
+---
+
+## 🚨 Mimir 503 Service Unavailable
+
+**Symptoms:**
+- Browser: "503 Service Temporarily Unavailable"
+- `kubectl get pods` shows: mimir-api in CrashLoopBackOff
+
+**Recovery (5-10 min):**
+
+```bash
+# Step 1: Check pod status
+kubectl get pods -n asgard -l app=mimir-api
+
+# Step 2: Read logs to find root cause
+kubectl logs -n asgard mimir-api-XXXXX --tail=50
+
+# Common issues:
+# - "ERROR 1045: Access denied" → MariaDB issue (see below)
+# - "Failed to initialize database" → Migration issue
+# - "Connection refused" → MariaDB not running
+```
+
+**If MariaDB auth error:**
+```bash
+# Check MariaDB is running
+kubectl get pods -n asgard-infra -l app=mariadb
+
+# If not ready, check why
+kubectl describe pod mariadb-XXXXX -n asgard-infra
+
+# If password is wrong, reset it
+kubectl exec mariadb-XXXXX -n asgard-infra -- mariadb -u root -proot -e \
+  "ALTER USER 'mimir'@'%' IDENTIFIED BY '<password>'; FLUSH PRIVILEGES;"
+
+# Restart Mimir
+kubectl delete pods -n asgard -l app=mimir-api
+```
+
+**If migration error:**
+```bash
+# This means stale DB state. Full reset needed:
+kubectl delete pvc mariadb-data -n asgard-infra
+kubectl delete pods -n asgard-infra -l app=mariadb
+# Wait for MariaDB to restart with fresh DB
+kubectl wait --for=condition=ready pod -l app=mariadb -n asgard-infra --timeout=60s
+
+# Then restart Mimir
+kubectl delete pods -n asgard -l app=mimir-api
+```
+
+---
+
+## 🚨 MariaDB Pod Stuck in Pending
+
+**Symptoms:**
+```
+mariadb-XXXXX   0/1     Pending   0           5m
+```
+
+**Recovery (5 min):**
+
+```bash
+# Check why it's pending
+kubectl describe pvc mariadb-data -n asgard-infra
+# Look for error in Events section
+
+# Option 1: Delete PVC to let K8s create fresh one
+kubectl delete pvc mariadb-data -n asgard-infra
+
+# Option 2: Check node capacity
+kubectl describe nodes
+# Look for "Allocatable" resources and "Allocated resources"
+```
+
+---
+
+## 🚨 Pod CrashLoopBackOff (Any Service)
+
+**Symptoms:**
+```
+eir-gateway-XXXXX   0/1     CrashLoopBackOff   5 (30s ago)
+```
+
+**Recovery (2-3 min):**
+
+```bash
+# Step 1: Get logs
+kubectl logs <pod-name> -n <namespace> --tail=100
+
+# Step 2: Identify error (look for ERROR, panic, failed to)
+
+# Step 3: Fix based on error type:
+
+# If image pull error:
+#   → Check imagePullPolicy is "Never" for K3s
+#   → Check docker image exists: docker image ls | grep <name>
+
+# If connection error:
+#   → Check dependent service is running
+#   → Check networking (kubectl get svc)
+
+# If config error:
+#   → Check env vars: kubectl describe pod <name>
+#   → Check secrets: kubectl get secrets -n <namespace>
+
+# Step 4: Restart pod
+kubectl delete pod <pod-name> -n <namespace>
+```
+
+---
+
+## 🚨 OrbStack / Local Docker Dead
+
+**Symptoms:**
+```
+Cannot connect to the Docker daemon at unix:///Users/mimir/.orbstack/run/docker.sock
+```
+
+**Recovery (5 min):**
+
+```bash
+# Force kill OrbStack
+pkill -9 -i orbstack
+
+# Clean up socket
+rm -rf ~/.orbstack/run
+
+# Restart OrbStack
+open /Applications/OrbStack.app
+
+# Wait ~10 seconds for Docker to come online
+docker ps
+
+# If still failing, check System Preferences → OrbStack
+```
+
+---
+
+## 🚨 Database User Missing (INC-2026-05-17-001)
+
+**Symptoms:**
+```
+ERROR 1045 (28000): Access denied for user 'mimir'@'X.X.X.X' (using password: YES)
+```
+
+**Recovery (3 min):**
+
+```bash
+# Check if user exists
+kubectl exec mariadb-XXXXX -n asgard-infra -- \
+  mariadb -u root -proot -e "SELECT user, host FROM mysql.user;"
+
+# If mimir user NOT listed:
+kubectl exec mariadb-XXXXX -n asgard-infra -- mariadb -u root -proot -e \
+  "CREATE USER 'mimir'@'%' IDENTIFIED BY '<password>';
+   GRANT ALL PRIVILEGES ON mimir.* TO 'mimir'@'%';
+   FLUSH PRIVILEGES;"
+
+# If user exists but password wrong:
+kubectl exec mariadb-XXXXX -n asgard-infra -- mariadb -u root -proot -e \
+  "ALTER USER 'mimir'@'%' IDENTIFIED BY '<password>';
+   FLUSH PRIVILEGES;"
+
+# Test connection
+kubectl exec mariadb-XXXXX -n asgard-infra -- \
+  mariadb -u mimir -p<password> -e "SELECT 'SUCCESS';"
+```
+
+**To prevent:** Run `./scripts/validate-k8s-before-deploy.sh` before deploy
+
+---
+
+## 🚨 Deployment Won't Complete (Stuck Rolling)
+
+**Symptoms:**
+```
+kubectl rollout status deployment/mimir-api -n asgard
+# Waiting for rollout to finish...
+```
+
+**Recovery (5 min):**
+
+```bash
+# Check pod events
+kubectl describe pod mimir-api-XXXXX -n asgard
+
+# Common causes:
+# - Readiness probe failing → pod not ready
+# - PVC not bound → storage issue
+# - Image pull failing → docker image missing
+
+# If pod is stuck on same error for >5 min, force restart
+kubectl rollout restart deployment/mimir-api -n asgard
+
+# Wait for new rollout
+kubectl rollout status deployment/mimir-api -n asgard --timeout=300s
+```
+
+---
+
+## 🚨 Can't Connect to Database from Local Machine
+
+**Symptoms:**
+```
+$ mysql -h 127.0.0.1 -u mimir -p
+ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1:3306'
+```
+
+**Recovery (2 min):**
+
+```bash
+# Check if MariaDB pod is port-forwarding
+kubectl port-forward -n asgard-infra svc/mariadb 3306:3306
+
+# In another terminal:
+mysql -h 127.0.0.1 -u mimir -p
+
+# Or use kubectl exec directly:
+kubectl exec -it mariadb-XXXXX -n asgard-infra -- \
+  mariadb -u mimir -p
+```
+
+---
+
+## Emergency: Reset Everything
+
+**⚠️ WARNING: This deletes all data. Only use if completely stuck.**
+
+```bash
+# Delete all Asgard resources
+kubectl delete namespace asgard asgard-infra --wait=true
+
+# Wait for deletion (~1 min)
+kubectl get namespace
+
+# Redeploy from scratch
+cd /Users/mimir/Developer/Asgard
+./scripts/validate-k8s-before-deploy.sh
+./scripts/deploy-all.sh
+
+# Verify
+kubectl get pods -A
+```
+
+---
+
+## Need Help?
+
+Before escalating:
+
+1. **Run validation script:**
+   ```bash
+   ./scripts/validate-k8s-before-deploy.sh
+   ```
+
+2. **Check logs:**
+   ```bash
+   kubectl logs <pod-name> -n <namespace> --tail=100
+   ```
+
+3. **Review recent changes:**
+   ```bash
+   git log --oneline -10
+   git diff HEAD~1
+   ```
+
+4. **Check incident history:**
+   - [Incident report](./docs/incidents/2026-05-17-mimir-503/incident-report.md)
+   - [Postmortem](./docs/incidents/2026-05-17-mimir-503/postmortem.md)
+
+---
+
+## Escalation
+
+If issue persists after recovery steps:
+
+1. Create incident in Linear (label: `asgard-incident`)
+2. Post in #incidents Slack channel with:
+   - Service affected
+   - Last known good time
+   - Error messages from logs
+   - Recovery steps already tried
+3. Page on-call engineer (if P1)
+
+---
+
+**Last updated:** 2026-05-18  
+**Related incident:** INC-2026-05-17-001  

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# 🚀 Asgard Platform — Master Deployment Script
+# One-command deploy all services (K8s + Heimdall)
+
+set -e
+
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ASGARD_ROOT="$(dirname "$SCRIPT_DIR")"
+HEIMDALL_ROOT="$(dirname "$ASGARD_ROOT")/Heimdall"
+
+# Configuration
+SKIP_K8S="${SKIP_K8S:-false}"
+SKIP_HEIMDALL="${SKIP_HEIMDALL:-false}"
+
+echo -e "${BLUE}"
+echo "╔═══════════════════════════════════════════════════════════╗"
+echo "║         🚀 Asgard Platform — Master Deploy                 ║"
+echo "╚═══════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+echo "Configuration:"
+echo "  Skip K8s:        $SKIP_K8S"
+echo "  Skip Heimdall:   $SKIP_HEIMDALL"
+echo ""
+
+# ─────────────────────────────────────────────────────────────
+# STEP 1: Deploy K8s Services
+# ─────────────────────────────────────────────────────────────
+
+if [ "$SKIP_K8S" != "true" ]; then
+  echo -e "${YELLOW}[Step 1/2]${NC} Deploying K8s Services..."
+  echo "────────────────────────────────────────────────────────────"
+
+  if [ -f "$SCRIPT_DIR/k3s-deploy.sh" ]; then
+    bash "$SCRIPT_DIR/k3s-deploy.sh"
+  else
+    echo -e "${RED}❌ k3s-deploy.sh not found${NC}"
+    exit 1
+  fi
+
+  echo -e "${GREEN}✅ K8s deployment complete${NC}"
+  echo ""
+else
+  echo -e "${YELLOW}[Step 1/2]${NC} Skipping K8s (SKIP_K8S=true)"
+  echo ""
+fi
+
+# ─────────────────────────────────────────────────────────────
+# STEP 2: Deploy Heimdall Services
+# ─────────────────────────────────────────────────────────────
+
+if [ "$SKIP_HEIMDALL" != "true" ]; then
+  echo -e "${YELLOW}[Step 2/2]${NC} Deploying Heimdall Services..."
+  echo "────────────────────────────────────────────────────────────"
+
+  if [ -f "$HEIMDALL_ROOT/scripts/quick-setup.sh" ]; then
+    cd "$HEIMDALL_ROOT"
+    bash scripts/quick-setup.sh
+  else
+    echo -e "${RED}❌ Heimdall scripts not found${NC}"
+    exit 1
+  fi
+
+  echo -e "${GREEN}✅ Heimdall deployment complete${NC}"
+  echo ""
+else
+  echo -e "${YELLOW}[Step 2/2]${NC} Skipping Heimdall (SKIP_HEIMDALL=true)"
+  echo ""
+fi
+
+# ─────────────────────────────────────────────────────────────
+# SUMMARY
+# ─────────────────────────────────────────────────────────────
+
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}✅ Deployment Complete!${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo ""
+
+if [ "$SKIP_K8S" != "true" ]; then
+  echo "K8s Status:"
+  kubectl get pods -n asgard | head -8
+  echo ""
+fi
+
+echo "📖 Documentation: DEPLOYMENT.md"


### PR DESCRIPTION
## Summary

Final supersede PR from [#64](https://github.com/MegaWiz-Dev-Team/Asgard/pull/64). Carries the deploy tooling chain that's coupled to the operational scripts in [#78](https://github.com/MegaWiz-Dev-Team/Asgard/pull/78) and the failure class documented in [#79](https://github.com/MegaWiz-Dev-Team/Asgard/pull/79).

| File | Why kept |
|---|---|
| [scripts/deploy-all.sh](scripts/deploy-all.sh) | One-command master deploy (K8s + Heimdall). `SKIP_K8S` / `SKIP_HEIMDALL` env knobs. `memory/asgard_complete_deploy_script` references this as canonical. |
| [QUICK_START.md](QUICK_START.md) | 60-second deploy recipe — tightly coupled to `deploy-all.sh`. |
| [DEPLOYMENT_CHECKLIST.md](DEPLOYMENT_CHECKLIST.md) | Pre-deploy checklist; first item runs `validate-k8s-before-deploy.sh` from [#78](https://github.com/MegaWiz-Dev-Team/Asgard/pull/78). Explicitly references INC-2026-05-17-001 ([#79](https://github.com/MegaWiz-Dev-Team/Asgard/pull/79)) as the failure class it prevents. |
| [RECOVERY_RUNBOOKS.md](RECOVERY_RUNBOOKS.md) | Common-incident recovery playbook (Mimir 503, MariaDB auth, etc.). Different scope from initial-deploy doc. |

## Audit — what was dropped from #64 and why

| File | Reason dropped |
|---|---|
| `DEPLOYMENT.md` (generic platform guide) | Duplicates the customer-facing [`docs/technical/customer-deployment-runbook.md`](docs/technical/customer-deployment-runbook.md) landed via [#72](https://github.com/MegaWiz-Dev-Team/Asgard/pull/72). |
| `RELEASE_NOTES.md` | Release notes belong in tags / CHANGELOG, not as a static doc that goes stale. |
| `k8s/02-services/{huginn,muninn,odin}.yaml` + `docs/roadmap/huginn-muninn.md` | Huginn/Muninn now private commercial (memory `asgard_huginn_scanner`). Odin manifest is OK in principle but lives in a stale-helm context — defer to a focused helm PR. |
| Helm chart edits | Main has moved 77 commits since the branch base; per-chart review needed in a focused PR, not bundled here. |

## Supersede summary for #64

| PR | Content | Status |
|---|---|---|
| [#78](https://github.com/MegaWiz-Dev-Team/Asgard/pull/78) | Rotation + validate scripts (5 files) | Auto-merge armed |
| [#79](https://github.com/MegaWiz-Dev-Team/Asgard/pull/79) | INC-2026-05-17-001 incident bundle (6 files) | Auto-merge armed |
| [#80](https://github.com/MegaWiz-Dev-Team/Asgard/pull/80) | ADR-008 Lab Extraction HITL (1 file) | Auto-merge armed |
| **this PR** | deploy-all + 3 docs (4 files) | — |
| dropped | DEPLOYMENT.md, RELEASE_NOTES.md, Huginn/Muninn manifests, stale helm edits | Not salvaged (see audit table above) |

After this lands, [#64](https://github.com/MegaWiz-Dev-Team/Asgard/pull/64) will be closed with a comment pointing to these 4 PRs.

## Test plan

- [ ] `scripts/deploy-all.sh` skim: `SKIP_*` env knobs, error handling, no destructive ops without confirmation.
- [ ] `DEPLOYMENT_CHECKLIST.md` step 1 ↔ `validate-k8s-before-deploy.sh` (in [#78](https://github.com/MegaWiz-Dev-Team/Asgard/pull/78)) match.
- [ ] `RECOVERY_RUNBOOKS.md` does not contradict the customer-deployment-runbook recovery references.
- [ ] No overlap with content already in `docs/technical/customer-deployment-runbook.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)