### PR TITLE
docs: align component docs with finalized roster + visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ graph LR
     EirGW --> |"proxy"| Eir["📋 OpenEMR<br/>FHIR R4"]
     Fenrir --> |"Browser"| Eir
 
+    Heimdall --> |"PII/DLP gate"| Skuggi["🕶️ Skuggi<br/>Guardrail (in-process)"]
     Heimdall --> LLM["🍎 MLX Backend (LLM)<br/>⚡ ONNX (Embedding)"]
 
     Yggdrasil["🌳 Yggdrasil<br/>Auth (Zitadel)"] -.-> Heimdall
@@ -58,6 +59,7 @@ graph LR
     style Huginn fill:#020617,stroke:#94a3b8,color:#e2e8f0
     style Tyr fill:#450a0a,stroke:#f87171,color:#fecaca
     style LogShipper fill:#450a0a,stroke:#f87171,color:#fecaca
+    style Skuggi fill:#1e1b4b,stroke:#a78bfa,color:#ddd6fe
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,18 +77,12 @@ graph TB
     Yggdrasil["🌳 Yggdrasil<br/>Auth"] -.-> Hermodr
 ```
 
-| Component | Role | Tech | Status |
-|:--|:--|:--|:--|
-| ⚡ **Bifrost** | Multi-Agent Orchestrator | **Rust (Axum + rig.rs)** | 🚧 Migrating to Rust |
-| 📨 **Hermóðr** | Universal MCP Sidecar | Rust | ✅ v0.1.0 |
-| 🏥 **Eir** | FHIR Gateway + Context Router | Rust (Axum) | ✅ v0.4.0 |
-| 🧠 **Mimir** | Knowledge Engine (Curator + Researcher) | Rust (Axum) + Next.js | ✅ Sprint 29 |
-| 🐺 **Fenrir** | Computer Use Agent | Rust + Python sidecar | ✅ v0.3.0 |
-| 🐿️ **Ratatoskr** | Shared Headless Browser | Rust (Axum) | ✅ Active |
-| 🛡️ **Heimdall** | LLM Gateway + Step-up Router | Rust (Axum) | ✅ Production |
-| 🌳 **Yggdrasil** | Identity & Auth (SSO/JWT) | Go (Zitadel) | ✅ v0.5.0 |
-| 🔱 **Odin** | Platform Supervisor | Rust (Axum) | 📋 Planned |
-| 🛡️ **Várðr** | Monitoring & Tracing | Rust | 📋 Planned |
+> 📋 **Canonical roster:** the full component list, tech stack, status, and
+> **Access (🌐 Public / 🔒 Private)** lives in the root README to avoid drift —
+> see **[Components](../README.md#-components)** and **[Norse Naming](../README.md#%EF%B8%8F-norse-naming)**.
+> Private repos: Yggdrasil, Týr, Huginn, Muninn, Syn, asgard-underwriter (Iris).
+> Skuggi (PII/DLP guardrail) is in-process middleware, not a standalone repo;
+> Sága (STT), Bragi (TTS), and Laminar → `heimdall-trace` are planned.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 > A self-hosted AI platform running entirely on Apple Silicon & NVIDIA GPU.
 >
-> *Updated: 2026-03-14 — Eir Gateway Chat UI, MCP/A2A integration protocol (8 components)*
+> *Updated: 2026-05-22 — component roster + repo visibility (Public/Private) aligned with the [root README](../README.md#-components). Skuggi PII/DLP guardrail, heimdall-trace (formerly Laminar), planned Sága/Bragi.*
 
 ## High-Level Overview
 
@@ -411,11 +411,16 @@ graph LR
 
 ---
 
-### 👁️ Laminar — LLM Observability (Trace & MLOps)
+### 👁️ heimdall-trace (formerly Laminar) — LLM Observability (Trace & MLOps)
+
+> Reassigned 2026-05-19: this component is absorbed into the **Heimdall family**
+> as the `heimdall-trace` submodule rather than a standalone Norse-named service
+> (family: `heimdall` · `heimdall-trace` · future `heimdall-horn`). The name
+> "Sága" once proposed here was reassigned to Speech-to-Text.
 
 ```mermaid
 graph LR
-    subgraph laminar["👁️ Laminar System"]
+    subgraph laminar["👁️ heimdall-trace System"]
         UI["🖥️ Dashboard<br/>Traces · Evaluations"]
         LmnrAPI["📡 API/Ingest<br/>Rust Backend"]
         ClickHouse["🗄️ ClickHouse<br/>OLAP Traces"]


### PR DESCRIPTION
Makes the supporting docs consistent with the finalized component roster + repo visibility (root README is now canonical).

- **README** — add Skuggi (PII/DLP guardrail) node to the architecture diagram.
- **docs/README.md** — replace the drifting/partial component table (conflicting statuses, no Access column, missing Skuggi/Týr/Syn/Huginn/Muninn/Sága/Bragi) with a pointer to the canonical roster in the root README. Removes permanent drift.
- **docs/architecture.md** — rename **Laminar → `heimdall-trace`** (Heimdall family, reassigned 2026-05-19); refresh the stale "updated 2026-03-14 / 8 components" header.

Net diff = 3 files (README.md, docs/README.md, docs/architecture.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)