### PR TITLE
docs: open-core policy (3-tier IP boundary) + Skuggi extraction plan

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,5 +1,10 @@
 # 🏰 Asgard AI Platform — Commercial Licensing
 
+> **Which components are open vs closed?** See the canonical [Open-Core Policy](OPEN_CORE_POLICY.md)
+> ([ADR-023](docs/decisions/ADR-023-open-core-ip-boundary.md)). That document is the source of truth;
+> if anything below conflicts with it, the policy wins. Note: some components listed below as public
+> (e.g. Yggdrasil) are now **private/commercial** per the policy — table pending reconciliation.
+
 ## Open Source License
 
 The Asgard AI Platform is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**.

--- a/OPEN_CORE_POLICY.md
+++ b/OPEN_CORE_POLICY.md
@@ -1,0 +1,138 @@
+# 🏰 Asgard Open-Core Policy
+
+**Status:** Active
+**Owner:** paripol@megawiz.co
+**Last updated:** 2026-05-30
+**Canonical source of truth** for which Asgard components are open, copyleft, or closed.
+See also: [ADR-023](docs/decisions/ADR-023-open-core-ip-boundary.md), [COMMERCIAL.md](COMMERCIAL.md), [LICENSE](LICENSE).
+
+---
+
+## Why this document exists
+
+Asgard's open/closed split had been happening **ad hoc** — security scanners (Huginn/Muninn)
+were made private for one reason, crates were published for another. Without a written
+boundary, each new component gets classified inconsistently, which erodes **both** the moat
+*and* community trust over time.
+
+This policy makes the boundary explicit and the rule for new components mechanical.
+
+## The principle (one rule)
+
+> **Open the platform, close the defenses and the tuned domain IP.**
+>
+> A component is **AGPL-public** by default. It moves to **private/commercial** only if it is
+> (a) a *security/identity* control where exposing the implementation weakens the protection,
+> or (b) *tuned domain IP* that a competitor could lift to skip months of work.
+> Interface/protocol/client glue that helps integration but is not a moat is **permissive-open**.
+
+The AGPL license *is* the moat for the open tier — copyleft already prevents a competitor from
+taking the platform closed and reselling it as a hosted service. We do **not** need to close a
+component just to protect it from SaaS competitors; AGPL does that for free. We close only when
+AGPL is insufficient (the two cases above).
+
+> ❗ Never relicense Asgard's own open code as MIT/Apache — that removes the copyleft moat.
+> External dependencies keep their own upstream terms.
+
+---
+
+## The three tiers
+
+### 🔒 Tier C — Private / Commercial (closed source)
+
+Security, identity, and tuned-defense IP. Sold/licensed; not in public repos.
+
+| Component | Repo | Why closed |
+|-----------|------|------------|
+| **Syn** | `MegaWiz-Dev-Team/Syn` (private) | OCR engine + tuned detectors; also carries internal real-data coupling |
+| **Tyr** | `MegaWiz-Dev-Team/Tyr` (private) | SIEM / threat detection — exposing rules tells attackers how to evade |
+| **Huginn** | `MegaWiz-Dev-Team/Huginn` (private) | Security scanner (cyber-security commercial split) |
+| **Muninn** | `MegaWiz-Dev-Team/Muninn` (private) | Auto-fix / security remediation (commercial split) |
+| **Yggdrasil** | `MegaWiz-Dev-Team/Yggdrasil` (private) | Identity / auth service — attack surface, keep implementation closed |
+| **Skuggi** | _to be extracted → `MegaWiz-Dev-Team/Skuggi` (private)_ | PII guardrail — the tuned detector rules are a defense; exposing them tells an adversary exactly what slips through. **See migration note below.** |
+
+### 🌐 Tier B — AGPL-3.0 (public, copyleft)
+
+The medical/insurance platform. Public for auditability and clinician/regulator trust;
+AGPL stops competitors from closing it.
+
+| Component | Repo | Role |
+|-----------|------|------|
+| **Bifrost** | `MegaWiz-Dev-Team/Bifrost` (public) | Orchestrator |
+| **Heimdall** | `MegaWiz-Dev-Team/Heimdall` (public) | LLM Gateway |
+| **Mimir** | `MegaWiz-Dev-Team/Mimir` (public) | RAG + Agent Builder |
+| **Eir** | `MegaWiz-Dev-Team/Eir` (public) | Clinical agent gateway |
+| **refgraph** | `MegaWiz-Dev-Team/refgraph` (public) | Reference-graph engine |
+| **Odin** | `MegaWiz-Dev-Team/Odin` (public) | (public utility) |
+
+> **Agent configs are not in this tier — they are not code.** The 19 Eir specialty agents,
+> tool allowlists, and medical reasoning preambles live as **rows in `agent_configs`** (DB),
+> shipped per-box. The public Eir/Bifrost code can orchestrate agents but does not contain the
+> tuned medical configuration. That data is effectively Tier C by storage, not by repo.
+
+### 📦 Tier A — Permissive (public, integration glue)
+
+Commodity interfaces that help partners/SIs integrate. Not a moat → permissive license OK.
+
+| Artifact | Where | Note |
+|----------|-------|------|
+| **`syn-client-types`** | crates.io `v0.1.x` | OCR request/response DTOs; codenames already sanitized before publish |
+| **FHIR types** | mimir-fhir crate | R5 canonical types; standards-based, no moat |
+| **Protocol / SDK glue** | per-repo | client stubs, wire types |
+
+---
+
+## Rule for any NEW component
+
+1. **Default = Tier B (AGPL).**
+2. Move to **Tier C** only if it answers *yes* to: *"Does publishing the implementation make
+   our security/identity weaker, or hand a competitor our tuned domain IP?"*
+3. Move to **Tier A** only if it is pure interface/protocol with no moat value.
+4. Record the classification in this table in the same PR that creates the component.
+5. Tuned data (agent configs, detector rulesets, weights) is shipped per-box / privately even
+   when the surrounding engine is Tier B.
+
+---
+
+## Current state vs target (gap log)
+
+As of 2026-05-30, actual GitHub visibility matches this policy **except** Skuggi.
+
+| Item | Target | Actual | Action |
+|------|--------|--------|--------|
+| Syn, Tyr, Huginn, Muninn, Yggdrasil | private | private | ✅ none |
+| Bifrost, Heimdall, Mimir, Eir, refgraph, Odin | AGPL public | public | ✅ none |
+| **Skuggi (`skuggi-core`)** | private | **public** (lives in Mimir + consumed by Heimdall) | ⏳ extract — see below |
+
+### Skuggi extraction migration note
+
+`skuggi-core` (the Tier-1 PII regex + scoring crate, ~311 LOC) currently lives at
+`Mimir/ro-ai-bridge/skuggi-core` and is consumed via **path dependency by two public repos**:
+Mimir (leak-detection) and Heimdall (`gateway/src/skuggi.rs` redaction glue).
+
+⚠️ **Naively making `skuggi-core` a private code dependency breaks the public builds of both
+Mimir and Heimdall** — they could no longer compile without private-repo access, which
+contradicts the Tier-B "auditable, community-buildable" promise.
+
+The extraction must therefore split **engine (public) from rules (private)**, not just move the
+crate. Recommended pattern, to execute when the proprietary detectors (Skuggi W2–W4 / NER) land:
+
+- Keep a public `skuggi-core` engine + a basic default ruleset so Tier-B repos build & run.
+- Ship the **tuned detector ruleset + weights** as private data / a feature-gated private crate,
+  loaded at runtime on commercial/on-prem builds.
+
+Until then the exposed surface is standard PII regexes (Thai national-ID, phone, email), which
+carries low IP risk. The migration is tracked here rather than rushed in a way that breaks
+public builds.
+
+➡️ **Detailed migration plan:** [docs/technical/skuggi-extraction-migration.md](docs/technical/skuggi-extraction-migration.md)
+(engine stays public in `skuggi-core`; tuned rules ship as a private data file from a new private
+`MegaWiz-Dev-Team/Skuggi` repo via `SKUGGI_RULES_PATH` — no public repo is flipped private).
+
+---
+
+## Maintenance
+
+- This file is canonical. `COMMERCIAL.md` and any per-repo README must not contradict it.
+- `COMMERCIAL.md` currently links some Tier-C repos (e.g. Yggdrasil) as if public — reconcile.
+- Review on every new component and at each release.

--- a/docs/decisions/ADR-023-open-core-ip-boundary.md
+++ b/docs/decisions/ADR-023-open-core-ip-boundary.md
@@ -1,0 +1,75 @@
+# ADR-023: Open-Core IP Boundary (which components are open, copyleft, or closed)
+
+**Status:** Accepted
+**Date:** 2026-05-30
+**Deciders:** paripol@megawiz.co
+**Scope:** Platform-wide (all current and future Asgard components)
+**Related:** [OPEN_CORE_POLICY.md](../../OPEN_CORE_POLICY.md), [COMMERCIAL.md](../../COMMERCIAL.md), ADR-007 (Skuggi), ADR-009 (single-tenant deployment)
+
+## Context
+
+The question "should we stop open-sourcing Asgard?" came up. Investigation showed the open/closed
+split had been evolving **ad hoc**: security scanners (Huginn/Muninn) and identity (Yggdrasil) went
+private for commercial/security reasons, several crates were published, and the medical platform
+stayed public — but there was **no written rule**. Without one, each new component risks
+inconsistent classification, which erodes both the moat and community trust.
+
+Actual GitHub visibility at decision time:
+
+- **Public:** Asgard, Bifrost, Heimdall, Mimir, Eir, refgraph, Odin
+- **Private:** Syn, Tyr, Huginn, Muninn, Yggdrasil
+
+A proposal to *additionally* close Bifrost + refgraph and extract Skuggi was considered. But
+Bifrost and refgraph are already public, and refgraph's core is **already published to crates.io**
+(cannot be unpublished). Closing them would be high-cost and low-reversibility for little gain,
+and would contradict a boundary the team had effectively already chosen.
+
+## Decision
+
+Adopt a **three-tier open-core model** with one governing principle:
+
+> **Open the platform; close the defenses and the tuned domain IP. AGPL is the moat for the open tier.**
+
+- **Tier C — Private/Commercial:** Syn, Tyr, Huginn, Muninn, Yggdrasil, and **Skuggi** (security,
+  identity, tuned-defense IP).
+- **Tier B — AGPL-3.0 public:** Bifrost, Heimdall, Mimir, Eir, refgraph, Odin (the medical/insurance
+  platform — public for audit/trust; AGPL prevents closed resale).
+- **Tier A — Permissive public:** `syn-client-types`, FHIR types, protocol/SDK glue (commodity
+  interfaces, no moat).
+
+New components default to **Tier B**, moving to Tier C only if publishing weakens security/identity
+or hands over tuned IP, and to Tier A only if pure interface. Tuned **data** (agent configs, detector
+rulesets, weights) ships privately/per-box even when its engine is Tier B. Full classification table
+and the rule live in [OPEN_CORE_POLICY.md](../../OPEN_CORE_POLICY.md).
+
+**Do not** blanket-close the platform: it would forfeit the moat AGPL already provides and the
+clinician/regulator trust that open auditability buys, in exchange for IP protection AGPL + per-box
+private data already deliver.
+
+### Skuggi (the one open item)
+
+Skuggi belongs in Tier C, but its `skuggi-core` crate (~311 LOC of Tier-1 PII regex + scoring)
+currently lives in public Mimir and is consumed by public Heimdall via path dependency. Making it a
+private code dependency would break both public builds. Therefore the extraction is **deferred and
+must split engine (public) from rules (private)** — see the migration note in the policy doc. The
+currently exposed surface is standard PII regexes (low IP risk), so this is tracked, not rushed.
+
+## Alternatives Considered
+
+1. **Blanket close-source everything (rejected).** Forfeits AGPL's free moat and the trust/audit
+   value of an open medical platform; irreversible damage to brand and partner relations.
+2. **Stay fully MIT/Apache open (rejected).** Removes copyleft protection — a competitor could take
+   the platform closed and resell it. Contradicts existing licensing memory.
+3. **Execute the earlier "also close Bifrost + refgraph" proposal (rejected).** Bifrost/refgraph are
+   already public and refgraph is published to crates.io (un-publish impossible); high cost, low
+   reversibility, minimal added protection over AGPL.
+4. **Three-tier open-core, extract Skuggi only (accepted).** Codifies the boundary the team had
+   effectively chosen, adds the one missing closure (Skuggi) in a non-build-breaking way.
+
+## Consequences
+
+- A mechanical rule now governs new-component classification; reduces drift.
+- `COMMERCIAL.md` must be reconciled — it links some Tier-C repos (e.g. Yggdrasil) as if public.
+- Skuggi extraction becomes a tracked engineering task gated on the proprietary detectors (W2–W4)
+  existing, implemented as engine/rules split.
+- No public repo is flipped private as a result of this ADR (avoids breaking links/forks/crates).

--- a/docs/technical/skuggi-extraction-migration.md
+++ b/docs/technical/skuggi-extraction-migration.md
@@ -1,0 +1,127 @@
+# Skuggi Extraction Migration Plan (engine public / rules private)
+
+**Status:** Steps 1–2 DONE (2026-05-31) · Steps 3–5 gated on Skuggi W2–W4/NER
+**Date:** 2026-05-30 (plan) · 2026-05-31 (steps 1–2 executed)
+**Owner:** paripol@megawiz.co
+**Drives:** the deferred action in [OPEN_CORE_POLICY.md](../../OPEN_CORE_POLICY.md) Tier-C / Skuggi gap
+**Related:** [ADR-023](../decisions/ADR-023-open-core-ip-boundary.md), ADR-007 (Skuggi)
+
+## Goal
+
+Make Skuggi's **tuned PII-detection IP** private without breaking the public builds of Mimir and
+Heimdall (both AGPL Tier-B), and without a private *code* dependency that would make those repos
+un-buildable from public source.
+
+## Why the obvious approach fails
+
+`skuggi-core` lives at `Mimir/ro-ai-bridge/skuggi-core` (public) and is consumed by **path
+dependency** from:
+
+| Consumer | Repo | API used |
+|----------|------|----------|
+| `gateway/src/skuggi.rs` (re-export) | Heimdall (public) | `redact_chat_body`, `redact_text`, `scan_categories`, `Detection`, `RedactionResult` |
+| `routes/admin_skuggi.rs` | Mimir (public) | `scan_categories` |
+| `routes/a2a.rs` | Mimir (public) | `redact_text` |
+| `bin/skuggi_leak_runner.rs`, `bin/skuggi_bench.rs` | Mimir (public) | `scan_categories` |
+
+Moving `skuggi-core` into a private repo and depending on it privately → **both public repos stop
+compiling without private access.** That breaks the Tier-B "community-buildable / auditable"
+promise. So we must split, not relocate.
+
+## The split: engine (public) vs rules (private)
+
+Looking at `skuggi-core/src/lib.rs`, the file already separates cleanly:
+
+- **Engine = generic plumbing, NO IP value → stays public in `skuggi-core`:**
+  `ReplaceMode`, `Detection`, `RedactionResult`, `redact_text`, `scan_categories`,
+  `redact_chat_body`. These are format-agnostic — they apply *whatever* ruleset they are given.
+- **Rules = the tuned IP → becomes private:** the regex `static`s + the ordered `patterns()`
+  dispatch table (categories, placeholders, replace modes, ordering rationale). Today this is 8
+  standard patterns (Thai ID/phone/email + 5 form anchors). Low IP value *now*; high once W2–W4
+  / NER detectors and tuned weights land — which is exactly what we're protecting for.
+
+### Recommended mechanism: private **rules data file**, not a private crate
+
+Refactor `patterns()` from compile-time `&'static Regex` statics into a runtime-loaded `RuleSet`:
+
+```rust
+// skuggi-core (PUBLIC) — engine + a generic, non-proprietary default ruleset
+pub struct Rule { pub category: String, pub placeholder: String,
+                  pub regex: Regex, pub mode: ReplaceMode }
+pub struct RuleSet { rules: Vec<Rule> }
+
+impl RuleSet {
+    /// Generic baseline so public builds detect & run out of the box.
+    pub fn builtin() -> Self { /* the current standard 8 patterns */ }
+
+    /// Commercial/on-prem: load tuned rules from a data file if present,
+    /// else fall back to builtin(). NO private code dependency.
+    pub fn load() -> Self {
+        match std::env::var("SKUGGI_RULES_PATH") {
+            Ok(p) => Self::from_toml_path(&p).unwrap_or_else(|_| Self::builtin()),
+            Err(_) => Self::builtin(),
+        }
+    }
+    pub fn from_toml_path(path: &str) -> anyhow::Result<Self> { /* parse TOML → compile regex */ }
+}
+
+// Engine functions take &RuleSet (or read a process-global set once).
+pub fn redact_text(rules: &RuleSet, text: &str) -> RedactionResult { /* unchanged logic */ }
+```
+
+The **tuned ruleset ships only as a data file** (`skuggi-rules.toml` + future model artifacts) on
+commercial/on-prem images, distributed from the private **`MegaWiz-Dev-Team/Skuggi`** repo. Public
+source contains only `builtin()` (generic patterns). Result:
+
+- Public Mimir + Heimdall **build and run** from public source (using `builtin()`). ✅
+- No private *code* dependency in any public repo. ✅
+- The tuned detectors/weights/models live exclusively in the private Skuggi repo as data. ✅
+- On-prem boxes set `SKUGGI_RULES_PATH=/etc/asgard/skuggi-rules.toml` (dropped in at deploy). ✅
+
+> Rejected alternative: a feature-gated private `skuggi-rules` **crate**. Works, but commercial CI
+> then needs private-repo build access and the public/commercial build graphs diverge. The data-file
+> approach keeps even commercial builds buildable from public source + a dropped-in file. Pick the
+> crate only if rules need compiled Rust logic (not just patterns) — revisit when NER lands.
+
+## Step-by-step (each step keeps all repos green)
+
+1. ✅ **DONE 2026-05-31 — Refactor in place (public, no behavior change).** In `skuggi-core`,
+   introduced `Rule`/`RuleSet`, moved the 8 patterns into `RuleSet::builtin()`, and made
+   `redact_text`/`scan_categories`/`redact_chat_body` methods on `&RuleSet`. Added `RuleSet::load()`
+   (env `SKUGGI_RULES_PATH` → `from_toml_path`/`from_toml_str`, else `builtin()`). Kept the existing
+   **free functions** with identical signatures as thin wrappers over a `once_cell` process-global
+   `Lazy<RuleSet>` = `load()`, so all Heimdall + Mimir callsites compile unchanged. Crucially,
+   `Detection.category` / `scan_categories` stay **`&'static str`** (Mimir's
+   `pii_matches_in_response: Vec<&'static str>` depends on it) — loaded rules `Box::leak` their
+   category/placeholder once at startup. **Bumped skuggi-core 0.1.0 → 0.2.0** (+ `toml` dep; updated
+   Mimir workspace requirement to `0.2`). Added `toml` dep. **Verified:** skuggi-core 17/17 tests;
+   Heimdall gateway skuggi 27/27 (incl. all leak-contract tests) — behaviour identical to v0.1;
+   `ro-ai-bridge` + Heimdall gateway both compile (`SQLX_OFFLINE=true`).
+2. ✅ **DONE 2026-05-31 — Wire `load()` at startup.** Heimdall `main.rs` now calls
+   `skuggi_core::init_default_rules()` eagerly at boot (just before the tenant-config cache),
+   logging the active detector count and whether a custom `SKUGGI_RULES_PATH` is in use — so a bad
+   path surfaces at startup, not on the first proxied request. Mimir relies on lazy global init at
+   first use (per-request path; no hot-path startup wiring needed). Leak-contract tests confirm
+   `builtin()` reproduces today's redaction exactly.
+3. **Create private repo `MegaWiz-Dev-Team/Skuggi`.** Contents: `skuggi-rules.toml` (the tuned
+   ruleset, initially = builtin exported to TOML, then extended privately), the tuning/eval harness
+   (move `skuggi_bench.rs` / `skuggi_leak_runner.rs` here if they embed proprietary corpora — keep
+   public smoke versions), and future W2–W4 / NER model artifacts. License: `LicenseRef-Commercial`.
+4. **Deploy wiring.** Add `SKUGGI_RULES_PATH` to the on-prem/commercial image build + customer
+   deployment runbook; drop `skuggi-rules.toml` from the private repo into the image. Public/dev
+   builds leave it unset → `builtin()`.
+5. **Verify gap closed.** `grep` confirms no tuned patterns remain in public repos beyond the
+   generic `builtin()`. Update [OPEN_CORE_POLICY.md](../../OPEN_CORE_POLICY.md) gap log: Skuggi → done.
+
+## Trigger / timing
+
+Per ADR-023, execute steps 3–5 **when the proprietary detectors (Skuggi W2–W4 / NER) actually
+exist** — that's when there is real IP to protect. Steps 1–2 (the refactor enabling runtime rules)
+are safe to land anytime and are a prerequisite, so they can go first independently.
+
+## Reversibility note
+
+Steps 1–2 are ordinary refactors (fully reversible). Step 3 creates a *new private* repo (does not
+touch public repo visibility — nothing flips public→private, so no broken links/forks/crates). This
+plan deliberately avoids the irreversible moves (un-publishing crates, privatizing public repos)
+that the rejected "close Bifrost/refgraph" proposal would have required.


### PR DESCRIPTION
Codify the open/closed boundary that had been evolving ad hoc.

## What
- **OPEN_CORE_POLICY.md** (canonical): 3 tiers —
  - 🔒 private/commercial: Syn, Tyr, Huginn, Muninn, Yggdrasil, Skuggi
  - 🌐 AGPL public: Bifrost, Heimdall, Mimir, Eir, refgraph, Odin
  - 📦 permissive: client crates (syn-client-types, FHIR types, SDK)
  - Principle: *open the platform, close the defenses + tuned domain IP; AGPL is the moat for the open tier.* Mechanical rule for classifying new components.
- **ADR-023**: records the decision; rejects blanket-close and the "also close Bifrost/refgraph" idea (already public; refgraph crate published — un-publishable).
- **docs/technical/skuggi-extraction-migration.md**: engine(public)/rules(private) split via a runtime rules data file (`SKUGGI_RULES_PATH`), **not** a private code dependency, so public Mimir/Heimdall builds never break. Steps 1–2 already implemented (see companion PRs).
- **COMMERCIAL.md**: point to the policy; flag stale public-listed Tier-C repos (e.g. Yggdrasil) pending reconciliation.

## Companion PRs (steps 1–2 of the Skuggi split)
- Mimir: `feat/skuggi-core-ruleset` — skuggi-core 0.2.0 RuleSet
- Heimdall: `feat/skuggi-rules-startup-load` — eager rule-set init at boot

Docs only. No code/visibility change in this PR.