### PR TITLE
docs(analytics): ADR-024 asgard_analytics tenant + execution plan

### DIFF
--- a/docs/decisions/ADR-024-asgard-analytics-tenant-and-data-engine.md
+++ b/docs/decisions/ADR-024-asgard-analytics-tenant-and-data-engine.md
@@ -1,0 +1,152 @@
+# ADR-024: Asgard Analytics — Data-Analysis Tenant + Data/Geo Engine
+
+**Status:** Accepted
+**Date:** 2026-06-08 (accepted 2026-06-09)
+**Deciders:** paripol@megawiz.co
+**Scope:** New tenant `asgard_analytics` + two cross-cutting Mimir submodules
+**Related:** ADR-009 (single-tenant Mac mini), ADR-010 (agents as boundaries / skills as expertise), ADR-012/014 (data-plane ownership = Mimir family), ADR-023 (open-core IP boundary), [feedback: tenant = domain not org], [feedback: include Tyr/Skuggi in PII designs]
+
+## Context
+
+Megawiz needs a capability to **analyze, visualize, research, and run spatial analysis** over three
+kinds of data:
+
+1. **External datasets** uploaded by an analyst (CSV / Parquet / Excel / GeoJSON).
+2. **Cross-tenant Asgard operational metrics** (OCR / Eir / eval benchmarks already in
+   `asgard_platform`, `asgard_medical`, `asgard_insurance`).
+3. **External public / research data** (open data, epidemiology, geo layers).
+
+Spatial scope is **both GIS** (lat/long, choropleth, distance/buffer, clustering) **and statistical
+spatial** (Moran's I / LISA, kriging, point-pattern). Consumption is **human-analyst dashboard +
+agent-driven (ReAct) + scheduled research reports**.
+
+Two orthogonal questions had to be separated:
+
+- **Capability (service):** where does the compute live? — answered by new submodules.
+- **Isolation (tenant):** is "analytics" its own data/governance domain? — answered by a new tenant.
+
+The three data sources include externally-sourced and uploaded data whose PII/governance regime is
+**different from medical PHI**. Folding analytics into `asgard_medical` would pollute the PHI
+boundary and force cross-tenant federation, which contradicts ADR-009 ("1 Mac mini per customer").
+
+## Decision
+
+Adopt a **two-part design** that keeps capability and isolation on separate axes.
+
+> **Build analytics compute as cross-cutting Mimir submodules; isolate analytics data and agents
+> behind their own thin tenant. Rust-first for the engines; Python only inside a sandbox for
+> spatial statistics.**
+
+### Part A — Services (capability, cross-cutting, Tier B / AGPL)
+
+Two new submodules under the **Mimir** family (per ADR-012/014 data-plane ownership and the
+"no new Norse components — extend as `<parent>-<submodule>`" rule):
+
+- **`mimir-lab`** — dataset registry + ingestion (CSV/Parquet/Excel/GeoJSON) + schema inference +
+  **DuckDB**-backed SQL/analytics engine. Pure Rust host (`duckdb-rs`); DuckDB `spatial` extension
+  enabled. Reads files directly; persists a Parquet-on-disk catalog + MinIO blobs (both already in
+  stack).
+- **`mimir-geo`** — geospatial engine on **GeoRust** (`geo` / `geos` / `proj` / `geozero` /
+  `geoarrow-rs`) + DuckDB spatial + **h3o** (pure-Rust H3). GIS ops in Rust; **statistical-spatial
+  ops run in a sandboxed Python kernel (PySAL / scipy)** — a deliberate, scoped exception to the
+  Rust-First Principle because the Rust spatial-stats ecosystem is immature (same precedent as
+  mlx-lm for fine-tuning).
+
+Both are **Tier B (AGPL-3.0 public)** per ADR-023 default for new components — they are commodity
+analytical engines, not tuned domain IP or defenses. Any tenant may call them.
+
+### Part B — Tenant (isolation, thin boundary)
+
+Create tenant **`asgard_analytics`** (display name "Asgard Analytics"), parallel to
+`asgard_medical` / `asgard_insurance` / `asgard_platform`, per "tenant = domain not org":
+
+- **Agents** — an `analyst-*` family seeded as rows in `agent_configs` (clone-Eir pattern, **local
+  LLM only** = gemma-4-26b): `analyst-router`, `analyst-sql`, `analyst-geo`, `analyst-stats`,
+  `analyst-research`. Each has its own tool allowlist (separate from Eir). Agent configs + any tuned
+  rulesets are **Tier C** (private, per-box tuned data) even though the engines are Tier B.
+- **Guardrails** — a **Skuggi** dataset-upload PII-scan policy scoped to this tenant (separate from
+  medical), and **Tyr** audit on every query / export. (Required by "include Tyr/Skuggi in PII
+  designs".)
+- **Shared-knowledge surface** — a row in `/api/v1/knowledge/shared` + UI page (required by "shared
+  knowledge surface" rule; no silently-invisible KB).
+- **Recovery script** — `Mimir/scripts/recover-asgard-analytics.sql` recreates tenant + agents
+  (mirrors `recover-asgard-tenant.sql`).
+
+### Cross-tenant federation (bounded)
+
+`asgard_analytics` may read cross-tenant metrics **only via a read-only adapter that is toggleable
+and default-off on customer boxes**. On the internal/dev box it behaves like `asgard_platform`
+(cross-cutting, PII-free metrics). It must **not** become a permanent federation layer — that would
+violate ADR-009.
+
+### Research agent (`analyst-research`, deep-research pattern)
+
+The "do research" requirement is served by `analyst-research`, built on the **`deep-research`
+orchestration pattern** (fan-out searches → **adversarially verify each claim** → cited synthesis)
+rather than a wholesale third-party engine. DARE (de-anthropocentric-research-engine) was evaluated
+and **rejected as a runtime** — it is a Claude-Code markdown-skill arsenal assuming a frontier model
+and "autonomous, without permission" operation, which is the wrong runtime (Asgard agents are
+Bifrost ReAct loops on local gemma-4-26b) and conflicts with Asgard's humans-in-loop governance. We
+**borrow its design patterns only**: the machine-readable Research Spec (with falsifiability audit +
+backtrack conditions) and the literature → gap → hypothesis → stress-test structure.
+
+- **Runtime:** Bifrost ReAct loop / workflow, **not** ported skills.
+- **Sources:** Mimir RAG (internal corpus) + license-clean external connectors **Semantic Scholar +
+  arXiv** via Hermodr (`lit_search`). **No web scraping** (Apify-style) — conflicts with on-prem/PII
+  posture.
+- **HITL by default:** the agent proposes specs / hypotheses; a human approves. It does not act
+  autonomously.
+- **Verify-everything:** every external claim is adversarially verified before it enters a report,
+  matching Asgard's review ethos.
+
+**Open sub-decision (flagged, default applied):** deep research on local gemma-4-26b is
+quality-limited (reasoning-heavy; KB-grounding variance is high per the eir-kb-grounding finding).
+Default policy = **local-first; cloud LLM is an opt-in, Skuggi-gated, default-off flag** scoped to
+the research path only (mirrors insurance Skuggi-gating; cloud spend stays under the Heimdall oracle
+budget cap). Unlike medical/insurance, `asgard_analytics` *may* enable the cloud research path per
+box — to be confirmed before P5.
+
+### Orchestration & UX
+
+- **ReAct + scheduled** runs go through Bifrost (`bifrost-agent` live, `bifrost-jobs` cron) — no new
+  orchestrator.
+- **MCP tools** exposed via **Hermodr**: `dataset_list/upload/profile`, `run_sql`, `plot`,
+  `geo_*` (buffer/distance/join/choropleth/h3), `stats_*` (describe/correlate/regress/moran/kriging),
+  `lit_search` (Semantic Scholar + arXiv, for `analyst-research`).
+- **Visualization** in `asgard-portal` (React): **Apache ECharts** (charts) + **MapLibre GL** +
+  **PMTiles/Protomaps** offline tiles (on-prem, no token).
+- **Scheduled research reports** via **Evidence.dev** (SQL + markdown over DuckDB), driven by
+  `bifrost-jobs`.
+
+## Alternatives Considered
+
+1. **Service only, no tenant (rejected).** Analytics becomes a feature inside each existing tenant.
+   Pollutes the PHI boundary, scatters PII policy, and forces cross-tenant federation that breaks
+   ADR-009.
+2. **Tenant only, stretch existing Mimir (rejected).** Still need the compute capability somewhere;
+   bolting dataset/geo storage onto core Mimir without a submodule boundary muddies the data-plane
+   ownership set in ADR-012/014.
+3. **Extend `asgard_platform` instead of a new tenant (rejected).** `asgard_platform` is hash-only /
+   PII-free for internal benchmarks; analytics ingests external + uploaded data that may contain PII,
+   so it needs its own governance regime.
+4. **PostGIS as the geo backend (rejected as default).** GPL-2.0, heavyweight relational dependency;
+   DuckDB spatial + GeoRust cover the needs with a clean (MIT/Apache) license and Rust-first fit.
+   Revisit only if relational geo at scale becomes a hard requirement.
+5. **Python/pandas as the primary engine (rejected).** Violates Rust-First Principle; Python is
+   confined to the sandboxed spatial-stats kernel only.
+
+## Consequences
+
+- **Positive:** clean PHI isolation; reusable analytics engines for every tenant; a productizable
+  "analytics box" template; Rust-first/local-LLM/on-prem all preserved; license-clean OSS stack.
+- **Negative / cost:** two new submodules to build + maintain; one sanctioned Python sandbox
+  (supply-chain + memory-pressure surface — must serialize heavy ops per the Mac-mini memory rule);
+  cross-tenant adapter needs careful default-off gating per box.
+- **Open-core:** `mimir-lab` + `mimir-geo` engines → Tier B AGPL; `analyst-*` configs + rulesets →
+  Tier C private per-box.
+
+## Follow-ups
+
+- Execution detail: [asgard-analytics-execution-plan.md](../strategy/asgard-analytics-execution-plan.md)
+- Update `OPEN_CORE_POLICY.md` classification table with the two submodules.
+- Update the Asgard pantheon map memory once submodules land.

--- a/docs/strategy/asgard-analytics-execution-plan.md
+++ b/docs/strategy/asgard-analytics-execution-plan.md
@@ -1,0 +1,220 @@
+# Asgard Analytics — Execution Plan
+
+**Owner:** paripol@megawiz.co
+**Date:** 2026-06-08
+**Decision of record:** [ADR-024](../decisions/ADR-024-asgard-analytics-tenant-and-data-engine.md)
+**Principles in force:** Rust-First • local-LLM-only for agents • TDD • SemVer • backup-before-state-change • Tyr/Skuggi in every PII path • single-tenant-per-box
+
+---
+
+## 0. Architecture at a glance
+
+```
+                          ┌────────────────────────── asgard-portal (React) ──────────────────────────┐
+                          │  ECharts (charts)   MapLibre GL + PMTiles (maps)   notebook/exploratory view │
+                          └───────────────▲───────────────────────────────────────────▲────────────────┘
+                                          │ REST / SSE                                  │
+              ┌───────────────────────────┴───────────────┐                ┌───────────┴───────────┐
+              │ Bifrost                                    │                │ Evidence.dev          │
+              │  bifrost-agent (ReAct, live)               │                │ (SQL+md research      │
+              │  bifrost-jobs  (scheduled reports)         │                │  reports over DuckDB) │
+              └───────────────┬────────────────────────────┘                └───────────┬───────────┘
+                              │ tool calls (MCP)                                          │
+                       ┌──────┴───────┐                                                   │
+                       │ Hermodr      │  dataset_* · run_sql · plot · geo_* · stats_*     │
+                       └──────┬───────┘                                                   │
+          Heimdall ◀─ LLM ─── │ (gemma-4-26b, local only)                                 │
+                              ▼                                                            ▼
+         ┌────────────────────────────────────┐        ┌────────────────────────────────────────┐
+         │ mimir-lab (Rust, Tier B)            │        │ mimir-geo (Rust, Tier B)                 │
+         │  • dataset registry + ingest        │◀──────▶│  • GeoRust (geo/geos/proj/geozero)       │
+         │  • schema inference                 │ shares │  • DuckDB spatial · h3o                   │
+         │  • DuckDB engine (+spatial ext)     │ DuckDB │  • spatial-stats → Python sandbox        │
+         │  • Parquet-on-disk + MinIO blobs    │        │    (PySAL / scipy), serialized           │
+         └───────────────┬────────────────────┘        └────────────────────────────────────────┘
+                         │ every upload / query / export
+                ┌────────┴────────┐         ┌──────────────┐
+                │ Skuggi PII scan │         │ Tyr audit log │
+                └─────────────────┘         └──────────────┘
+
+   Tenant boundary: asgard_analytics  (agent_configs rows: analyst-router/-sql/-geo/-stats/-report)
+```
+
+---
+
+## 1. Data model (`mimir-lab`, new tables; tenant-scoped)
+
+All tables carry `tenant_id` (= `asgard_analytics`). Migration via the existing Mimir migration tooling.
+
+| Table | Purpose | Key columns |
+|---|---|---|
+| `datasets` | registry of every dataset | `id`, `tenant_id`, `name`, `source_type` (upload/cross_tenant/external), `schema_json`, `storage_uri`, `row_count`, `pii_status` (pending/clean/flagged), `created_by`, `created_at` |
+| `dataset_versions` | immutable snapshots | `id`, `dataset_id`, `version`, `storage_uri`, `checksum`, `created_at` |
+| `analyses` | saved query/notebook artifacts | `id`, `tenant_id`, `title`, `kind` (sql/notebook/geo), `spec_json`, `created_by`, `updated_at` |
+| `report_jobs` | scheduled report config | `id`, `tenant_id`, `name`, `cron`, `analysis_id`, `evidence_template`, `last_run`, `status` |
+| `geo_layers` | registered spatial layers | `id`, `dataset_id`, `geom_type`, `crs`, `bbox`, `feature_count` |
+
+- **Storage:** raw + versioned data as **Parquet on disk**; large blobs/originals in **MinIO**;
+  DuckDB is the query layer (attaches Parquet, no second copy). Agent configs stay in `agent_configs`.
+- **PII gate:** a row may not move from `pii_status=pending` to queryable until Skuggi scan completes.
+
+---
+
+## 2. MCP tool catalog (Hermodr) — the agent's hands
+
+| Tool | Backed by | Notes |
+|---|---|---|
+| `dataset_list` / `dataset_profile` | mimir-lab | schema, stats, null %, sample (PII-masked) |
+| `dataset_upload` | mimir-lab + Skuggi | triggers PII scan; returns `pii_status` |
+| `run_sql` | mimir-lab (DuckDB) | read-only role; row-cap + timeout; Tyr-audited |
+| `plot` | portal/ECharts spec | returns a Vega/ECharts spec, not an image |
+| `geo_buffer` / `geo_distance` / `geo_join` / `geo_choropleth` / `geo_h3` | mimir-geo | GeoRust + DuckDB spatial |
+| `stats_describe` / `stats_correlate` / `stats_regress` | mimir-lab | cheap stats in-engine |
+| `stats_moran` / `stats_lisa` / `stats_kriging` / `stats_pointpattern` | mimir-geo → Python sandbox | heavy; serialized, one at a time |
+| `lit_search` | Hermodr → Semantic Scholar + arXiv | external literature; license-clean sources; **no scraping**; results adversarially verified before use |
+
+Guardrails on every tool: read-only DB role, query timeout, row cap, Tyr audit, Skuggi-gated inputs.
+
+---
+
+## 3. Agent family (`analyst-*`, clone-Eir, local LLM only)
+
+Seeded by `Mimir/scripts/seed-asgard-analytics-agents.sql`. UI tool labels **must match** the
+runtime `kb_tool_label` names in Bifrost (Agent Studio has no validation — known footgun).
+
+| Agent | Role / preamble focus | Tool allowlist |
+|---|---|---|
+| `analyst-router` | classify request → route to sql/geo/stats/report | (routing only) |
+| `analyst-sql` | tabular Q&A, aggregation, charting | `dataset_*`, `run_sql`, `plot`, `stats_describe/correlate` |
+| `analyst-geo` | GIS reasoning, maps, choropleth | `dataset_*`, `geo_*`, `plot` |
+| `analyst-stats` | regression + spatial statistics | `dataset_*`, `run_sql`, `stats_*` |
+| `analyst-research` | deep-research: fan-out → adversarially verify → cited synthesis; compose report | all read tools + `plot` + `lit_search` |
+
+All on `gemma-4-26b` (Heimdall local). Heimdall already injects `enable_thinking:false` for local MLX.
+
+**`analyst-research` design** — built on the **`deep-research` orchestration pattern** (fan-out
+searches → verify each claim → cited synthesis), borrowing DARE's machine-readable **Research Spec**
+(falsifiability audit + backtrack conditions) and literature→gap→hypothesis→stress-test structure —
+**not** DARE's markdown-skill runtime. Runs as a Bifrost ReAct loop / workflow. Sources = Mimir RAG +
+`lit_search` (Semantic Scholar/arXiv). **HITL by default** (proposes specs/hypotheses; human
+approves). See §6 for the local-vs-cloud quality decision.
+
+---
+
+## 4. Phased delivery
+
+> Effort is rough dev-days on the single Mac mini, serial where memory pressure forces it.
+
+### P0 — Foundations & decision (≈1 day)
+- [x] Land ADR-024 (Accepted 2026-06-09).
+- [x] Update `OPEN_CORE_POLICY.md` Tier B table (mimir-lab/mimir-geo).
+- [x] Author tenant seed `Mimir/scripts/seed-asgard-analytics-tenant.sql` (idempotent, rollback noted).
+- [x] Author agent seed `Mimir/scripts/seed-asgard-analytics-agents.sql` (5 analyst-* agents; tool
+      names flagged as placeholders pending P2 Hermodr registration).
+- [x] **Backup step 0 (2026-06-09):** `scripts/backup-full-k8s.sh` → `/Volumes/T7 Shield/asgard-backup-2026-06-09`; gzip-tested OK incl. mariadb-asgard. (Known gaps: minio.tar.gz FAIL — distroless no-tar, needs helper-pod; Vault keys MANUAL.)
+- [x] **Applied to live DB (2026-06-09).** ⚠️ **Tenancy is split across TWO MariaDB instances:**
+  - `tenants` / `tenant_configs` → **asgard-infra** MariaDB → tenant seed applied (1 row).
+  - `agent_configs` → **asgard** MariaDB → agent seed applied (5 analyst-* rows, published).
+  - There is **no `tenants` table in the `asgard` MariaDB**; agent registry is `tenant_id`-column only.
+- [x] Restarted `deploy/bifrost -n asgard` (rollout OK).
+- [ ] Add shared-knowledge catalog row + UI page stub (P1 — when mimir-lab lands a KB surface).
+
+### P1 — `mimir-lab` MVP (≈4–5 days) — **vertical slice DONE 2026-06-09** (`Mimir` commit 63693f9)
+- [x] Scaffold Rust crate `ro-ai-bridge/mimir-lab` (own `[workspace]` like mimir-fhir; `duckdb` bundled — no system dep, build 1m34s). Spatial ext available in bundled build, wiring deferred to P4/mimir-geo.
+- [x] Migrations for the 5 tables (§1) → `migrations/0001_init_analytics.sql`. **TDD:** 8 integration tests, all green.
+- [x] CSV ingest → schema inference (`ingest_csv`); Parquet export (`export_parquet`). *Parquet/Excel/GeoJSON ingest + MinIO catalog = next increment.*
+- [x] `run_sql` read-only path: read-only statement guard + row-cap + CAST-to-VARCHAR fetch (`Engine::query_readonly`). *Query timeout + `dataset_list/profile` (registry/sqlx) = next increment.*
+- [x] **Skuggi** `pii_status` gate (`Pending`/`Clean`/`Flagged`) via skuggi-core Tier-1 (`pii::scan_samples`, `gate_table_column`). *Tyr audit on query/export = next increment.*
+- [x] Multi-format ingest CSV/Parquet/JSON via `SourceFormat` dispatcher (`Mimir` 213c118).
+- [x] **Registry persistence (sqlx)** — `registry::Registry` over MariaDB: register/list/get(profile)/update_pii_status/record_version/delete; env-gated integration test verified against live mimir db; **migration 0001 applied to live mimir db** (5 tables, additive) (`Mimir` 35ea46d).
+- [x] **Query timeout** — `query_readonly_timeout` via DuckDB `interrupt_handle` + watchdog (`Mimir` f78fc65).
+- [x] **Tyr audit** — `AuditSink` trait; engine audits every query (ok/timeout/denied/error). **Active `HttpTyrSink` forwards events to Tyr over HTTP** (same transport as Heimdall/`mimir-well::HttpProvSink`; `TYR_AUDIT_URL`/`TYR_AUDIT_TOKEN`, non-blocking channel-drained), `TracingAuditSink` fallback. wiremock-verified (`Mimir` 2f6bf54, tag `mimir-lab-v0.1.1`).
+- [x] **MinIO blob storage** — `storage::Storage` (rust-s3, path-style); verified live (bucket `asgard-analytics` created).
+- [x] **Tagged `mimir-lab-v0.1.0`** (`Mimir` f78fc65). 14 integration + registry + storage tests green.
+- [ ] *Deferred to later:* Parquet/Excel/GeoJSON ingest beyond CSV/JSON (Excel/GeoJSON need duckdb extensions → with mimir-geo in P4); wire registry+storage+engine into one dataset-upload flow (P2 with Hermodr).
+
+**P1 = DONE.** Next: **P2** (Hermodr MCP tools + analyst-* agents on the engine).
+
+### P2 — Agents + MCP (≈3–4 days) — **MCP tools + backend contract DONE 2026-06-09**
+- [x] **Hermodr tool definitions** — `services/analytics.rs`: `dataset_list`/`dataset_profile`/`run_sql`/`plot` (names match analyst-* allowlist); registered under SERVICE_NAME~='analytics' (hermodr-analytics sidecar). 3 tests green. (`Hermodr` 922d08c, branch `feat/asgard-analytics-tools`).
+- [x] **Backend contract** — `mimir-lab::api`: `run_sql` (read-only/capped/timed/audited → columns+rows), `plot` (→ ECharts option bar/line/scatter/pie), `dataset_list/profile` over registry. 5 handler tests green. (`Mimir` 2569724 on `feat/asgard-analytics-p0`).
+- [x] `analyst-*` agents seeded (P0) with matching tool names. *Still owed: verify UI tool labels == runtime names in Agent Studio once deployed.*
+- [ ] **Remaining P2:** stand up `analytics-api` server (axum bin over `mimir-lab::api`, spawn_blocking; dataset→table attachment from registry/MinIO) + deploy `hermodr-analytics` sidecar (UPSTREAM_URL) → then ReAct loop e2e (ask→route→run_sql→plot on gemma-4-26b) + E2E JSON-RPC verification (mirror Hermodr PrimeKG).
+- *Note:* `stats_*`/`geo_*`/`lit_search` tools come with mimir-geo (P4) / research (P5).
+
+### P3 — Portal visualization (≈4 days)
+- [ ] ECharts render of `plot` specs in `asgard-portal`.
+- [ ] Exploratory/notebook view (query → table → chart, interactive).
+- [ ] SSE streaming for ReAct reasoning trace (keep-alive >60s for Cloudflare).
+- [ ] Dataset upload UI + PII-status surfacing.
+
+### P4 — `mimir-geo` + spatial (≈5–6 days)
+- [ ] Scaffold crate; GeoRust + DuckDB spatial + h3o; share DuckDB handle with mimir-lab.
+- [ ] GIS ops (`geo_buffer/distance/join/choropleth/h3`) — **TDD** with fixture geometries.
+- [ ] **Python sandbox** for spatial-stats (PySAL/scipy): isolated venv, resource-capped,
+      **serialized** (memory-pressure rule), invoked only via `stats_moran/lisa/kriging/pointpattern`.
+- [ ] MapLibre GL + PMTiles offline tiles in portal; choropleth + point layers (deck.gl if needed).
+- [ ] Tag `mimir-geo v0.1.0`.
+
+### P5 — Research agent + scheduled reports (≈5 days)
+- [ ] Confirm local-vs-cloud research policy (§6); if cloud opt-in, wire Skuggi gate + oracle-budget cap.
+- [ ] `lit_search` connector via Hermodr → Semantic Scholar + arXiv (license-clean, no scraping).
+- [ ] `analyst-research` as Bifrost ReAct loop / workflow on the **deep-research pattern**
+      (fan-out → adversarial verify each claim → cited synthesis); Research Spec artifact with
+      falsifiability + backtrack conditions (DARE pattern, not its runtime). **HITL approval gate.**
+- [ ] Evidence.dev project wired to DuckDB; report templates.
+- [ ] `bifrost-jobs` cron → run analysis/research → render report → store + notify.
+- [ ] `report_jobs` UI (GitHub-Actions-style, reuse Bifrost cron monitor pattern) + manual trigger.
+
+### P6 — Cross-tenant adapter + hardening (≈2–3 days)
+- [ ] Read-only cross-tenant metrics adapter, **default-off**, per-box toggle (ADR-009 safety).
+- [ ] Load/latency check on Mac mini; ensure no parallel heavy ops; `sudo purge` headroom checks.
+- [ ] Security review (`/security-review`) on upload + query + export surfaces.
+- [ ] Docs + runbook + recovery drill.
+
+**Total:** ~24–28 dev-days. P1→P3 is the usable vertical slice (tabular analytics + viz); P4 adds
+spatial; P5 adds research agent + automation.
+
+---
+
+## 5. Open-source stack (license-checked)
+
+| Layer | Component | License | Role |
+|---|---|---|---|
+| SQL/OLAP engine | **DuckDB** + spatial ext | MIT | core of mimir-lab; reads CSV/Parquet/Excel; ST_* |
+| Rust dataframe (opt) | Polars / DataFusion | MIT / Apache-2.0 | if pure-Rust pipelines needed |
+| Geo | **GeoRust** (geo/geos/proj/geozero/geoarrow-rs) | MIT/Apache | mimir-geo |
+| Geo index | **h3o** | MIT | pure-Rust H3 hex indexing |
+| Spatial stats | **PySAL**, scipy, statsmodels | BSD | sandbox only |
+| Charts | **Apache ECharts** | Apache-2.0 | portal |
+| Maps | **MapLibre GL JS** + **PMTiles/Protomaps** | BSD | offline on-prem tiles |
+| Big geo layers (opt) | deck.gl | MIT | large point/hex layers |
+| Reports | **Evidence.dev** | MIT | scheduled SQL+md reports |
+| Research orchestration | **`deep-research` pattern** (in-harness) | — | template for `analyst-research`; fan-out + adversarial verify + cited synthesis |
+| Research patterns (ref only) | **DARE**, STORM, GPT-Researcher | Apache/MIT | design reference (Research Spec, gap/hypothesis loop) — **not adopted as runtime** |
+| Literature sources | Semantic Scholar MCP, arXiv | — | `lit_search`; license-clean; no scraping |
+
+Avoid: PostGIS (GPL, heavy — default-off), Metabase (source-available — don't embed), DARE/Apify
+scraping as a runtime (wrong runtime + cloud/autonomous, conflicts with on-prem HITL governance). All deps keep
+their own terms; Asgard's own `mimir-lab`/`mimir-geo` code is AGPL-3.0 (Tier B).
+
+---
+
+## 6. Risks & open questions
+
+1. **Mac-mini memory pressure** — DuckDB + gemma-4-26b + Python sandbox concurrently risks the
+   2026-05-21 kernel-panic class. Mitigation: serialize heavy ops, purge before load, cap sandbox RAM.
+2. **Cross-tenant adapter vs ADR-009** — must stay default-off per box; never a standing federation.
+3. **PII in uploads** — Skuggi must gate *before* data is queryable; flagged datasets quarantined.
+4. **Python supply chain** — pin + vendor the sandbox venv; no network at run time.
+5. **Tile data size** — PMTiles for Thailand/region only, not global, to fit on-box storage.
+6. **Research quality on local LLM** — deep research is reasoning-heavy; gemma-4-26b is
+   quality-limited and KB-grounding variance is high (eir-kb-grounding finding). **Decision (default
+   applied):** local-first; cloud LLM = opt-in, **Skuggi-gated, default-off**, research-path-only,
+   under the Heimdall oracle-budget cap. Unlike medical/insurance, `asgard_analytics` *may* enable it
+   per box — confirm before P5. Keep `analyst-research` HITL regardless of model.
+
+## 7. Definition of done (MVP = P0–P3)
+Analyst uploads a CSV → Skuggi-cleared → asks a question in the portal → `analyst-router` routes →
+`run_sql` + `plot` → interactive ECharts chart, reasoning trace streamed, every step Tyr-audited,
+all LLM calls local. Spatial (P4) and scheduled reports (P5) follow.


### PR DESCRIPTION
## Summary

Decision record + phased execution plan for the **Asgard Analytics** tenant (ADR-024).

- **ADR-024** — `asgard_analytics` tenant + two cross-cutting Mimir submodules (`mimir-lab` data engine, `mimir-geo` spatial). Two orthogonal axes: cross-cutting **services** (Tier-B AGPL) + a thin isolation **tenant**. Rust-first engines; Python only in a sandbox for spatial statistics. Research agent on the `deep-research` pattern (DARE evaluated and rejected as a runtime — wrong runtime + conflicts with humans-in-loop governance).
- **Execution plan** — P0–P6 (DuckDB/GeoRust/ECharts/MapLibre/Evidence.dev/PySAL), with P0 (tenant + agents), P1 (`mimir-lab` MVP), and P2 (MCP tools + backend contract) already implemented and ticked off.

## Test plan

Docs-only change — no code. The implementation these docs describe is verified in the sibling PRs:
- Mimir `feat/asgard-analytics` — `mimir-lab` engine, 26 tests green (+ live MariaDB/MinIO integration).
- Hermodr `feat/asgard-analytics-tools` — analytics MCP tools, 3 tests green.

## Notes
This PR carries only the two new analytics docs. The OPEN_CORE_POLICY Tier-B rows and the `backup-full-k8s.sh` MinIO helper-pod fix from the same work are held back — their target files are not yet on `main`, so they ride with their base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
