### PR TITLE
fix(security): MinIO root creds from secret, not minioadmin default

### DIFF
--- a/docs/security/minio-credential-rotation.md
+++ b/docs/security/minio-credential-rotation.md
@@ -1,0 +1,62 @@
+# MinIO credential rotation — remove the `minioadmin` default
+
+**Why:** the security scan found the MinIO root credentials hard-coded as the
+shipped default `minioadmin:minioadmin` — on the store that holds **FHIR + de-id
+analytics (PHI)** for Asgard Nótt, plus `mimir-uploads`. Both the **server**
+(`asgard-infra/minio`) root creds and **every client** used the default.
+(CWE-798 / OWASP A02:2025.) MinIO is `ClusterIP`-only, so this is defense-in-depth
+— but a default credential on a PHI store must be rotated.
+
+The manifests now read credentials from a `minio-credentials` secret. This
+rotation is a **coordinated, multi-namespace operation** — the server root
+password and all clients must switch together or clients will fail to auth.
+
+## Affected components (rotate together)
+
+| Component | Namespace | Where |
+|---|---|---|
+| MinIO **server** (root) | `asgard-infra` | `Asgard/k8s/01-infra/minio/02-deployment.yaml` |
+| mimir-sleep-api (Nótt) | `asgard` | `asgard-nott/k8s/mimir-sleep-api.yaml` + `s3sink.rs` |
+| Mimir lab / core-ai | `asgard` | `Mimir/ro-ai-bridge/mimir-lab/src/storage.rs`, `…/config.rs` |
+
+> Confirm the full list first: `grep -ril minioadmin` across all repos. Anything
+> still using `minioadmin` after rotation will break.
+
+## Rotation steps (minimal-downtime order)
+
+```sh
+# 1. Generate strong creds
+ACCESS=minio-asgard
+SECRET=$(openssl rand -base64 24)
+
+# 2. Create the SAME secret in every namespace that talks to MinIO
+for NS in asgard-infra asgard; do
+  kubectl -n "$NS" create secret generic minio-credentials \
+    --from-literal=access-key="$ACCESS" \
+    --from-literal=secret-key="$SECRET"
+done
+
+# 3. Apply manifests (now reference the secret) + restart server, then clients
+kubectl apply -f Asgard/k8s/01-infra/minio/02-deployment.yaml
+kubectl -n asgard-infra rollout restart deploy/minio        # server now uses new root creds
+kubectl apply -f asgard-nott/k8s/mimir-sleep-api.yaml
+kubectl -n asgard rollout restart deploy/mimir-sleep-api    # client picks up new creds
+# …repeat apply + rollout restart for every other client (Mimir, …)
+
+# 4. Verify: client can write to the bucket, no auth errors
+kubectl -n asgard logs deploy/mimir-sleep-api | grep -iE 's3|minio|denied|403' | tail
+```
+
+Between the server restart (step 3) and each client restart there is a brief
+window where that client gets `403`; PHI writes should retry. Restart clients
+immediately after the server.
+
+## Notes
+
+- **Don't commit real values.** The secret is created from the CLI (or sealed/
+  Vault-managed); `00-secret.template.yaml` carries placeholders only.
+- **Fail-closed:** `s3sink.rs` no longer falls back to `minioadmin` — a client
+  with no creds now errors instead of silently using the default.
+- **Hardening follow-up:** give each client a *dedicated* MinIO user scoped to
+  its bucket (`mc admin user add` + a bucket-scoped policy) instead of sharing
+  root. Then only the server holds root.

--- a/k8s/01-infra/minio/00-secret.template.yaml
+++ b/k8s/01-infra/minio/00-secret.template.yaml
@@ -1,0 +1,23 @@
+# MinIO root credentials — TEMPLATE ONLY (do NOT commit real values).
+#
+# Replace the placeholders and apply out-of-band, OR create from the CLI:
+#   ACCESS=minio-asgard
+#   SECRET=$(openssl rand -base64 24)
+#   kubectl -n asgard-infra create secret generic minio-credentials \
+#     --from-literal=access-key="$ACCESS" --from-literal=secret-key="$SECRET"
+#   # …and the SAME values in every client namespace (e.g. asgard) — see
+#   # docs/security/minio-credential-rotation.md for the full coordinated rotation.
+#
+# Replaces the hard-coded minioadmin/minioadmin default the security scan flagged
+# on this PHI/FHIR + analytics store. CWE-798 / OWASP A02:2025.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: asgard-infra
+  labels:
+    app: minio
+type: Opaque
+stringData:
+  access-key: "REPLACE_WITH_MINIO_ROOT_USER"
+  secret-key: "REPLACE_WITH_STRONG_GENERATED_PASSWORD"

--- a/k8s/01-infra/minio/02-deployment.yaml
+++ b/k8s/01-infra/minio/02-deployment.yaml
@@ -24,11 +24,15 @@ spec:
             - |
               mkdir -p /data/mimir-uploads
               minio server /data --console-address ":9001"
+          # Root credentials from the `minio-credentials` secret (asgard-infra).
+          # Create the secret BEFORE applying — see docs/security/minio-credential-rotation.md.
           env:
             - name: MINIO_ROOT_USER
-              value: "minioadmin"
+              valueFrom:
+                secretKeyRef: { name: minio-credentials, key: access-key }
             - name: MINIO_ROOT_PASSWORD
-              value: "minioadmin"
+              valueFrom:
+                secretKeyRef: { name: minio-credentials, key: secret-key }
           ports:
             - containerPort: 9000
             - containerPort: 9001

--- a/k8s/01-infra/minio/02-deployment.yaml
+++ b/k8s/01-infra/minio/02-deployment.yaml
@@ -34,8 +34,8 @@ spec:
               valueFrom:
                 secretKeyRef: { name: minio-credentials, key: secret-key }
           ports:
-            - containerPort: 9000
-            - containerPort: 9001
+            - { containerPort: 9000, name: api }
+            - { containerPort: 9001, name: console }
           volumeMounts:
             - name: storage
               mountPath: "/data"


### PR DESCRIPTION
## What
The MinIO **server** shipped with root credentials hard-coded as `minioadmin:minioadmin` on a PHI/FHIR + analytics store — found by a security scan (CWE-798 / OWASP A02:2025). Both the server root creds and every client used the default.

## Changes
- `k8s/01-infra/minio/02-deployment.yaml`: `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` now from the `minio-credentials` secret (`asgard-infra`).
- `k8s/01-infra/minio/00-secret.template.yaml`: placeholder secret (real values created out-of-band — not committed).
- `docs/security/minio-credential-rotation.md`: coordinated rotation runbook (server + every client, minimal-downtime order).

## Deploy note
This is a **coordinated rotation** — the server root password and all clients (mimir-sleep-api, Mimir lab/core-ai, …) must switch together or clients fail to auth. Follow the runbook; create the secret in every namespace BEFORE applying. **Not applied to prod here.** Pairs with MegaWiz-Dev-Team/asgard-nott#1 (client side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)