### PR TITLE
chore(scripts): graceful, data-safe Asgard shutdown + test harness

### DIFF
--- a/scripts/asgard-shutdown.sh
+++ b/scripts/asgard-shutdown.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# asgard-shutdown — graceful, data-safe shutdown of the Asgard stack on this
+# Mac mini. Codifies the manual procedure that avoids the failure mode behind
+# INC-2026-06-12 (a dirty stop → MariaDB / PVC corruption).
+#
+# Order of operations — each step is gated; nothing destructive runs unless the
+# step before it finished cleanly. It NEVER force-kills MariaDB or deletes state:
+#   1. read-only preflight        know the state before we touch it
+#   2. backup freshness gate      backup-first rule; snapshot if stale
+#   3. orb stop (graceful)        SIGTERM to every pod incl. MariaDB → flush
+#   4. (opt) stop host services   Heimdall MLX/VLM/gateway launchd jobs
+#   5. (opt) power off macOS      graceful Apple Event, sudo only as fallback
+#
+# Usage:
+#   ./asgard-shutdown.sh                stop the stack (orb stop), leave Mac on
+#   ./asgard-shutdown.sh --poweroff     stop the stack, then power off the Mac
+#   ./asgard-shutdown.sh --stop-host    also stop Heimdall host services
+#   ./asgard-shutdown.sh -y             non-interactive (assume yes to prompts)
+#   ./asgard-shutdown.sh --skip-backup  skip the backup gate (acknowledged)
+#   ./asgard-shutdown.sh --force-backup always snapshot first, even if fresh
+# Flags combine, e.g.  ./asgard-shutdown.sh --poweroff -y
+#
+# Env tunables: BACKUP_MAX_AGE_DAYS (default 1), T7_BASE (default /Volumes/T7 Shield)
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+# ── flags ─────────────────────────────────────────────────────────────────
+POWEROFF=0; STOP_HOST=0; ASSUME_YES=0; SKIP_BACKUP=0; FORCE_BACKUP=0
+for a in "$@"; do
+  case "$a" in
+    --poweroff|-p)  POWEROFF=1 ;;
+    --stop-host)    STOP_HOST=1 ;;
+    --yes|-y)       ASSUME_YES=1 ;;
+    --skip-backup)  SKIP_BACKUP=1 ;;
+    --force-backup) FORCE_BACKUP=1 ;;
+    -h|--help)      usage ;;
+    *) echo "unknown flag: $a (try --help)"; exit 64 ;;
+  esac
+done
+
+# ── tunables ──────────────────────────────────────────────────────────────
+BACKUP_MAX_AGE_DAYS="${BACKUP_MAX_AGE_DAYS:-1}"
+T7_BASE="${T7_BASE:-/Volumes/T7 Shield}"
+HEIMDALL_SERVICES=(
+  com.asgard.heimdall-gateway
+  com.asgard.heimdall-mlx
+  com.asgard.heimdall-vlm-q4
+  com.asgard.heimdall-vlm-q8
+  com.asgard.heimdall-vlm-qwen2
+)
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YEL='\033[1;33m'; BLU='\033[0;34m'; NC='\033[0m'
+say()  { echo -e "$@"; }
+step() { echo -e "\n${BLU}▶ $*${NC}"; }
+ok()   { echo -e "  ${GREEN}✅ $*${NC}"; }
+warn() { echo -e "  ${YEL}⚠️  $*${NC}"; }
+err()  { echo -e "  ${RED}❌ $*${NC}"; }
+die()  { echo -e "\n${RED}ABORT:${NC} $*"; exit 1; }
+
+# Plain-text prompts only (read -p does not interpret color escapes).
+confirm() {
+  [[ $ASSUME_YES -eq 1 ]] && return 0
+  local ans=""
+  read -r -p "  $1 [y/N] " ans </dev/tty || ans=""
+  [[ "$ans" =~ ^[Yy]$ ]]
+}
+
+# ── banner ────────────────────────────────────────────────────────────────
+echo -e "${BLU}🏰 Asgard safe shutdown${NC}"
+if [[ $POWEROFF -eq 1 ]]; then
+  echo -e "   plan: stop stack → ${RED}power off the Mac mini${NC}"
+else
+  echo -e "   plan: stop stack (orb stop), leave the Mac powered on"
+fi
+[[ $STOP_HOST -eq 1 ]] && echo -e "         + stop Heimdall host services"
+confirm "Proceed?" || { echo "cancelled."; exit 0; }
+
+# ── 1. preflight (read-only) ──────────────────────────────────────────────
+step "1/5  Pre-shutdown health (read-only)"
+if [[ -x "${SCRIPT_DIR}/asgard-preflight.sh" ]]; then
+  "${SCRIPT_DIR}/asgard-preflight.sh"
+  case $? in
+    0) ok "preflight clean" ;;
+    1) warn "preflight WARN (see above) — safe to continue a graceful stop" ;;
+    2) warn "preflight FAIL (see above). A FAIL such as a wedged pod does NOT"
+       warn "block a graceful stop — but review it before powering off."
+       confirm "Continue with shutdown anyway?" || die "stopped at preflight gate" ;;
+  esac
+else
+  warn "asgard-preflight.sh not found/executable — skipping health gate"
+fi
+
+# ── 2. backup freshness gate (backup-first rule) ──────────────────────────
+step "2/5  Backup gate"
+if [[ $SKIP_BACKUP -eq 1 ]]; then
+  warn "--skip-backup: not snapshotting (acknowledged)"
+else
+  AGE_D=""
+  if [[ -d "$T7_BASE" ]]; then
+    NEWEST=$(find "$T7_BASE" -maxdepth 4 -name '*.sql.gz' -type f 2>/dev/null \
+             | while IFS= read -r f; do stat -f '%m' "$f"; done | sort -rn | head -1)
+    [[ -n "$NEWEST" ]] && AGE_D=$(( ( $(date +%s) - NEWEST ) / 86400 ))
+  else
+    warn "T7 not mounted — cannot verify or refresh backups"
+  fi
+
+  if [[ $FORCE_BACKUP -eq 1 ]] || { [[ -n "$AGE_D" ]] && (( AGE_D > BACKUP_MAX_AGE_DAYS )); }; then
+    if [[ $FORCE_BACKUP -eq 1 ]]; then say "  --force-backup requested"
+    else warn "newest DB backup ${AGE_D}d old (> ${BACKUP_MAX_AGE_DAYS}d)"; fi
+    if confirm "Run a fresh backup now (nightly-backup.sh, can take minutes)?"; then
+      step "    backing up → T7 …"
+      "${SCRIPT_DIR}/nightly-backup.sh" \
+        && ok "backup complete" \
+        || warn "backup returned non-zero — check logs/nightly-backup.log before relying on it"
+    else
+      warn "skipping backup at user request"
+    fi
+  elif [[ -n "$AGE_D" ]]; then
+    ok "newest DB backup ${AGE_D}d old (≤ ${BACKUP_MAX_AGE_DAYS}d) — fresh enough"
+  fi
+fi
+
+# ── 3. graceful stack stop (orb stop) ─────────────────────────────────────
+step "3/5  Stopping OrbStack (graceful SIGTERM → MariaDB flushes & exits cleanly)"
+command -v orb >/dev/null 2>&1 || die "orb CLI not found — cannot stop the cluster gracefully"
+STATUS=$(orb status 2>/dev/null || true)
+if [[ "$STATUS" == "Stopped" ]]; then
+  ok "OrbStack already stopped"
+else
+  orb stop || die "orb stop failed — NOT powering off; investigate before forcing"
+  STATUS=$(orb status 2>/dev/null || true)
+  [[ "$STATUS" == "Stopped" ]] \
+    && ok "OrbStack stopped cleanly" \
+    || die "OrbStack did not reach 'Stopped' (got: ${STATUS:-?}) — investigate"
+fi
+
+# ── 4. host-native services (optional) ────────────────────────────────────
+step "4/5  Heimdall host services"
+if [[ $STOP_HOST -eq 1 ]]; then
+  for svc in "${HEIMDALL_SERVICES[@]}"; do
+    launchctl list 2>/dev/null | grep -q "$svc" || continue
+    launchctl bootout "gui/$(id -u)/$svc" 2>/dev/null \
+      && ok "stopped $svc" \
+      || warn "could not stop $svc (may already be down)"
+  done
+  warn "host services reload on next login/boot (RunAtLoad)"
+elif [[ $POWEROFF -eq 1 ]]; then
+  ok "leaving Heimdall to macOS shutdown to stop gracefully"
+else
+  ok "left running (stateless inference). Pass --stop-host to also stop them."
+fi
+
+# ── 5. power off (optional) ───────────────────────────────────────────────
+step "5/5  Power off"
+if [[ $POWEROFF -eq 0 ]]; then
+  ok "stack stopped, Mac left on. (re-run with --poweroff to also shut down macOS)"
+  exit 0
+fi
+confirm "Power off the Mac mini NOW?" || { warn "stack stopped but power-off cancelled — Mac left on"; exit 0; }
+say "  issuing graceful shutdown (Apple Event, no sudo)…"
+if osascript -e 'tell application "System Events" to shut down' 2>/dev/null; then
+  ok "shutdown signal sent — the Mac will power off shortly"
+  ok "if a GUI dialog blocks it, confirm on screen, or the sudo fallback runs below"
+else
+  warn "Apple Event shutdown failed — falling back to 'sudo shutdown' (asks for password)"
+  sudo shutdown -h now
+fi

--- a/scripts/test-asgard-shutdown.sh
+++ b/scripts/test-asgard-shutdown.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# test-asgard-shutdown — verify asgard-shutdown.sh's control flow WITHOUT any
+# real side effect. For each scenario it builds a sandbox, shims the dangerous
+# commands (orb / launchctl / osascript / sudo) and the heavy helpers
+# (asgard-preflight.sh / nightly-backup.sh) so every invocation is *logged* but
+# never executed for real, runs the REAL script (copied in), then asserts which
+# commands were — and were NOT — called, plus the exit code.
+#
+# Safe to run anytime: it touches only a mktemp sandbox. Exit 0 = all pass.
+set -uo pipefail
+
+SRC="$(cd "$(dirname "$0")" && pwd)/asgard-shutdown.sh"
+[[ -f "$SRC" ]] || { echo "FATAL: asgard-shutdown.sh not found next to this test"; exit 2; }
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; BLU='\033[0;34m'; NC='\033[0m'
+PASS=0; FAIL=0
+pass()  { PASS=$((PASS+1)); echo -e "    ${GREEN}✓${NC} $1"; }
+faild() { FAIL=$((FAIL+1)); echo -e "    ${RED}✗ $1${NC}"; }
+
+want_call() { grep -qF "$2" "$1/calls.log" && pass "$3" || faild "$3 — expected call '$2' not found"; }
+no_call()   { grep -qF "$2" "$1/calls.log" && faild "$3 — unexpected call '$2'" || pass "$3"; }
+want_rc()   { [[ "$2" == "$3" ]] && pass "$4 (rc=$2)" || faild "$4 — rc=$2 expected $3"; }
+
+make_sandbox() {
+  local d; d=$(mktemp -d)
+  mkdir -p "$d/bin" "$d/t7"; : > "$d/calls.log"
+  cp "$SRC" "$d/asgard-shutdown.sh"; chmod +x "$d/asgard-shutdown.sh"
+
+  # fake orb — stateful: status reflects whether 'stop' has run; honors ORB_STOP_FAILS
+  cat > "$d/bin/orb" <<EOF
+#!/usr/bin/env bash
+echo "orb \$*" >> "$d/calls.log"
+case "\$1" in
+  status) [[ -f "$d/.stopped" ]] && echo Stopped || echo Running ;;
+  stop)   [[ "\${ORB_STOP_FAILS:-0}" == 1 ]] && exit 1; touch "$d/.stopped" ;;
+esac
+EOF
+  # fake launchctl — 'list' returns the heimdall labels so the script's grep matches
+  cat > "$d/bin/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "launchctl \$*" >> "$d/calls.log"
+[[ "\$1" == list ]] && printf '%s\n' com.asgard.heimdall-gateway com.asgard.heimdall-mlx com.asgard.heimdall-vlm-q4 com.asgard.heimdall-vlm-q8 com.asgard.heimdall-vlm-qwen2
+exit 0
+EOF
+  # fake osascript — succeeds unless OSA_FAILS=1 (to exercise the sudo fallback)
+  cat > "$d/bin/osascript" <<EOF
+#!/usr/bin/env bash
+echo "osascript \$*" >> "$d/calls.log"
+[[ "\${OSA_FAILS:-0}" == 1 ]] && exit 1 || exit 0
+EOF
+  # fake sudo — log only, never actually elevate/run
+  cat > "$d/bin/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >> "$d/calls.log"; exit 0
+EOF
+  chmod +x "$d/bin/"*
+
+  # fake helpers in SCRIPT_DIR (the script calls these by \${SCRIPT_DIR}/name)
+  cat > "$d/asgard-preflight.sh" <<EOF
+#!/usr/bin/env bash
+echo "preflight \$*" >> "$d/calls.log"; exit \${PREFLIGHT_EXIT:-0}
+EOF
+  cat > "$d/nightly-backup.sh" <<EOF
+#!/usr/bin/env bash
+echo "nightly-backup \$*" >> "$d/calls.log"; exit 0
+EOF
+  chmod +x "$d/asgard-preflight.sh" "$d/nightly-backup.sh"
+
+  # a FRESH backup on the fake T7 by default → backup gate says "fresh enough"
+  : > "$d/t7/asgard_medical.sql.gz"
+  echo "$d"
+}
+make_stale() { touch -t 202001010000 "$1/t7/"*.sql.gz; }
+
+# run the copied script in sandbox $1 with the rest as flags; echoes its exit code.
+# fault vars (ORB_STOP_FAILS/OSA_FAILS/PREFLIGHT_EXIT) are inherited from the env.
+exec_script() {
+  local d="$1"; shift
+  PATH="$d/bin:$PATH" T7_BASE="$d/t7" "$d/asgard-shutdown.sh" "$@" >"$d/out.log" 2>&1
+  echo $?
+}
+fresh_env() { unset ORB_STOP_FAILS OSA_FAILS PREFLIGHT_EXIT; }
+
+echo -e "${BLU}▶ test-asgard-shutdown — shimmed behavioral checks${NC}"
+
+# ── S1: default (stop only), fresh backup ─────────────────────────────────
+echo -e "\n${BLU}S1${NC} default  →  orb stop, no power-off, no backup"
+fresh_env; D=$(make_sandbox); RC=$(exec_script "$D" -y)
+want_rc   "$D" "$RC" 0          "exit clean"
+want_call "$D" "preflight"      "preflight ran"
+want_call "$D" "orb stop"       "stack stopped"
+no_call   "$D" "osascript"      "did NOT power off"
+no_call   "$D" "sudo shutdown"  "did NOT sudo-shutdown"
+no_call   "$D" "launchctl bootout" "did NOT touch host services"
+no_call   "$D" "nightly-backup" "no backup (already fresh)"
+
+# ── S2: --poweroff (happy path) ───────────────────────────────────────────
+echo -e "\n${BLU}S2${NC} --poweroff  →  orb stop THEN graceful Apple-Event shutdown"
+fresh_env; D=$(make_sandbox); RC=$(exec_script "$D" --poweroff -y)
+want_rc   "$D" "$RC" 0          "exit clean"
+want_call "$D" "orb stop"       "stack stopped first"
+want_call "$D" "osascript"      "Apple-Event shutdown issued"
+no_call   "$D" "sudo shutdown"  "sudo fallback NOT used (osascript succeeded)"
+
+# ── S3: --poweroff but orb stop FAILS → must abort, NOT power off ──────────
+echo -e "\n${BLU}S3${NC} --poweroff + orb stop fails  →  abort, never power off"
+fresh_env; export ORB_STOP_FAILS=1; D=$(make_sandbox); RC=$(exec_script "$D" --poweroff -y)
+want_rc   "$D" "$RC" 1          "aborted (non-zero)"
+want_call "$D" "orb stop"       "attempted stop"
+no_call   "$D" "osascript"      "did NOT power off after failed stop"
+no_call   "$D" "sudo shutdown"  "did NOT sudo-shutdown after failed stop"
+
+# ── S4: --poweroff, osascript fails → sudo fallback ───────────────────────
+echo -e "\n${BLU}S4${NC} --poweroff + Apple-Event fails  →  sudo shutdown fallback"
+fresh_env; export OSA_FAILS=1; D=$(make_sandbox); RC=$(exec_script "$D" --poweroff -y)
+want_rc   "$D" "$RC" 0          "exit clean"
+want_call "$D" "osascript"      "tried Apple-Event first"
+want_call "$D" "sudo shutdown"  "fell back to sudo shutdown"
+
+# ── S5: --stop-host ───────────────────────────────────────────────────────
+echo -e "\n${BLU}S5${NC} --stop-host  →  bootout heimdall services, no power-off"
+fresh_env; D=$(make_sandbox); RC=$(exec_script "$D" --stop-host -y)
+want_rc   "$D" "$RC" 0              "exit clean"
+want_call "$D" "launchctl bootout" "stopped host services"
+want_call "$D" "orb stop"          "stack stopped"
+no_call   "$D" "osascript"         "did NOT power off"
+
+# ── S6: stale backup + --skip-backup → no backup ──────────────────────────
+echo -e "\n${BLU}S6${NC} stale backup + --skip-backup  →  backup skipped"
+fresh_env; D=$(make_sandbox); make_stale "$D"; RC=$(exec_script "$D" --skip-backup -y)
+want_rc   "$D" "$RC" 0          "exit clean"
+no_call   "$D" "nightly-backup" "backup skipped despite staleness"
+want_call "$D" "orb stop"       "stack still stopped"
+
+# ── S7: stale backup, no skip → backup runs first ─────────────────────────
+echo -e "\n${BLU}S7${NC} stale backup  →  fresh backup taken before stop"
+fresh_env; D=$(make_sandbox); make_stale "$D"; RC=$(exec_script "$D" -y)
+want_rc   "$D" "$RC" 0          "exit clean"
+want_call "$D" "nightly-backup" "stale → backup ran"
+want_call "$D" "orb stop"       "then stopped"
+
+# ── S8: preflight FAIL but -y proceeds ────────────────────────────────────
+echo -e "\n${BLU}S8${NC} preflight FAIL + -y  →  warns but proceeds"
+fresh_env; export PREFLIGHT_EXIT=2; D=$(make_sandbox); RC=$(exec_script "$D" -y)
+want_rc   "$D" "$RC" 0          "exit clean"
+want_call "$D" "orb stop"       "proceeded past FAIL with -y"
+
+# ── S9: no -y (no tty) → cancels before doing anything ────────────────────
+echo -e "\n${BLU}S9${NC} interactive, no tty  →  cancels at confirm, touches nothing"
+fresh_env; D=$(make_sandbox); RC=$(exec_script "$D")
+want_rc   "$D" "$RC" 0          "clean cancel"
+no_call   "$D" "preflight"      "cancelled before preflight"
+no_call   "$D" "orb stop"       "never stopped anything"
+
+# ── summary ───────────────────────────────────────────────────────────────
+echo -e "\n═══════════════════════"
+echo -e "Result: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+(( FAIL == 0 )) && exit 0 || exit 1


### PR DESCRIPTION
## What

Adds `scripts/asgard-shutdown.sh` — a gated, data-safe way to stop the Asgard
stack (and optionally power off the Mac mini), plus `scripts/test-asgard-shutdown.sh`
that verifies its control flow with **zero real side effects**.

Codifies the manual procedure that avoids the **INC-2026-06-12** failure mode
(a dirty stop → MariaDB / PVC corruption).

## `asgard-shutdown.sh`

Runs in order, each step gated — nothing destructive proceeds unless the step
before it finished cleanly. It never force-kills MariaDB or deletes state:

1. **read-only preflight** — know the state before touching it
2. **backup freshness gate** — snapshot if the newest DB backup is stale
3. **`orb stop`** — graceful SIGTERM to every pod incl. MariaDB → flush & exit
4. *(opt)* **stop host services** — Heimdall MLX/VLM/gateway launchd jobs (`--stop-host`)
5. *(opt)* **power off macOS** — graceful Apple Event, `sudo shutdown` only as fallback (`--poweroff`)

Two modes: stop the stack (default, leaves the Mac on) or `--poweroff`.
Flags: `--poweroff` `--stop-host` `--skip-backup` `--force-backup` `-y` `--help`.

## `test-asgard-shutdown.sh`

Builds a sandbox per scenario, shims the dangerous commands (`orb`/`launchctl`/
`osascript`/`sudo`) and heavy helpers (preflight/nightly-backup) so each call is
logged but never executed, runs the **real** script, then asserts which commands
were — and were NOT — called, plus exit code.

**9 scenarios, 33/33 assertions pass.** Key safety invariant covered: a failed
`orb stop` must abort **before** any power-off (never powers off on top of a
still-running cluster). Safe to run anytime: `./scripts/test-asgard-shutdown.sh`.

## Notes for reviewer

- Companion scripts `asgard-preflight.sh` / `asgard-watchdog.sh` are referenced
  but not yet on `main`; `asgard-shutdown.sh` **degrades gracefully** if preflight
  is absent (warns, skips the health gate).
- `nightly-backup.sh` (already tracked) is invoked as-is for the backup gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)