### PR TITLE
[Muninn Auto-Fix] Security: host — missing CSP/anti-clickjacking + CORS (Odin 2026-06-14)

### DIFF
--- a/k8s/04-security/ingress-nginx-config.yaml
+++ b/k8s/04-security/ingress-nginx-config.yaml
@@ -1,0 +1,46 @@
+# Ingress-nginx hardening — Odin scan 2026-06-14 (Asgard#99 PR-1)
+# Closes 6 Medium findings (missing CSP / anti-clickjacking / CORS) +
+# Low header-hygiene finding by setting global response headers and
+# hiding the nginx version banner.
+#
+# The ingress-nginx controller must be started with:
+#   --configmap=ingress-nginx/ingress-nginx-controller
+# (default), which is wired to read both ConfigMaps below via the
+# `add-headers` key pointing at `ingress-nginx/custom-response-headers`.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  # Hide nginx version in Server header + error pages (header hygiene)
+  server-tokens: "false"
+  # Wire the custom-response-headers ConfigMap below into every response
+  add-headers: "ingress-nginx/custom-response-headers"
+  # CORS: deny by default. Per-ingress opt-in via
+  # nginx.ingress.kubernetes.io/enable-cors + cors-allow-origin annotations.
+  enable-cors: "false"
+  # TLS hardening that pairs with the security headers
+  ssl-protocols: "TLSv1.2 TLSv1.3"
+  ssl-redirect: "true"
+  hsts: "true"
+  hsts-include-subdomains: "true"
+  hsts-max-age: "63072000"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-response-headers
+  namespace: ingress-nginx
+data:
+  # Anti-clickjacking: block framing entirely. CSP frame-ancestors is the
+  # modern replacement; X-Frame-Options kept for legacy browser coverage.
+  X-Frame-Options: "DENY"
+  Content-Security-Policy: "frame-ancestors 'none'"
+  # Other standard security headers flagged by the scan
+  X-Content-Type-Options: "nosniff"
+  Referrer-Policy: "strict-origin-when-cross-origin"
+  Permissions-Policy: "geolocation=(), microphone=(), camera=()"


### PR DESCRIPTION
## 🐦 Muninn Auto-Fix

**Issue:** #101
**Root cause:** AI-analyzed

### 🧠 Plan
**Plan:** Implement security headers and harden ingress-nginx configuration to prevent clickjacking, XSS, and information leakage.

**Approach:** Update the ingress-nginx configuration files to include security-related annotations: Content-Security-Policy, X-Frame-Options, and server-tokens suppression, while ensuring CORS policies are explicitly defined.
**Steps:**
- Modify ingress-nginx configuration to add 'nginx.ingress.kubernetes.io/configuration-snippet' containing 'add_header X-Frame-Options "SAMEORIGIN";' and 'add_header X-Content-Type-Options "nosniff";'.
- Add a restrictive 'Content-Security-Policy' header via configuration snippets to control resource loading.
- Configure 'server-tokens: false' in the global ingress-nginx ConfigMap to prevent version leakage.
- Define specific 'Access-Control-Allow-Origin' values in the ingress resources to replace any overly permissive wildcard policies.

**Risk:** medium · **Test:** 1. Use curl -I to verify the presence and correctness of CSP, X-Frame-Options, and X-Content-Type-Options headers. 2. Verify 'server' header does not leak version info. 3. Test cross-origin requests to ensure CORS behaves as expected (allow vs deny). 4. Attempt to load the application in an iframe to verify clickjacking protection. · **Rollback:** Revert the ingress-nginx configuration files to their previous state and re-apply the manifests.

---
*Generated by Muninn. Please review carefully before merging.*