### PR TITLE
fix(k8s/mimir-api): persist ALLOWED_ORIGINS so CORS fix survives redeploy

### DIFF
--- a/k8s/02-services/mimir-api/deployment.yaml
+++ b/k8s/02-services/mimir-api/deployment.yaml
@@ -25,6 +25,13 @@ spec:
           env:
             - name: PORT
               value: "8080"
+            # CORS allowlist (Mimir#364/#372) — replaces the old wildcard
+            # `Access-Control-Allow-Origin: *`. Comma-separated trusted origins;
+            # the dashboard reaches mimir-api server-side (cluster DNS) so these
+            # cover any browser-side caller. Without this the binary falls back
+            # to localhost-only, which would block the real dashboard origin.
+            - name: ALLOWED_ORIGINS
+              value: "https://mimir.asgard.internal,https://portal.asgard.internal,http://localhost:3000,http://localhost:5173"
             # DATABASE_URL + NEO4J_PASSWORD now come from envFrom: asgard-secrets
             # (defined below). Setting them here would override envFrom values
             # since `env` takes precedence over `envFrom` for matching keys.


### PR DESCRIPTION
Bakes the `ALLOWED_ORIGINS` env into the mimir-api deployment so the CORS fix (Mimir #372) isn't wiped on the next `kubectl apply` from the deploy script.

**Already applied live + verified** (`kubectl set env` + rollout):
- `Access-Control-Allow-Origin` now echoes the allowlisted origin, **no more `*`**
- foreign origin rejected (no ACAO header)
- mimir-api `/healthz` 200; dashboard reaches mimir-api **server-side** (cluster DNS) so it's unaffected

This PR just makes that durable in git. Allowlist = `mimir.asgard.internal` + `portal.asgard.internal` + localhost dev.

> Asgard branch protection requires review → needs admin-merge (like #104/#106/#107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)