### PR TITLE
fix(security): add CSP + security headers to asgard-portal launchpad

### DIFF
--- a/packages/asgard-portal/src/main.rs
+++ b/packages/asgard-portal/src/main.rs
@@ -1,5 +1,8 @@
 use axum::{
-    response::Html,
+    extract::Request,
+    http::{header, HeaderName, HeaderValue},
+    middleware::{self, Next},
+    response::{Html, Response},
     routing::get,
     Router,
 };
@@ -7,11 +10,50 @@ use std::net::SocketAddr;
 
 const INDEX_HTML: &str = include_str!("index.html");
 
+/// Security response headers (defense-in-depth alongside ingress).
+///
+/// The launchpad is a static HTML page with no JavaScript, so `script-src 'self'`
+/// drops `'unsafe-inline'` entirely. It uses an inline `<style>` block + a couple
+/// of inline `style=` attributes and loads Google Fonts, so `style-src` keeps
+/// `'unsafe-inline'` and allowlists fonts.googleapis.com / fonts.gstatic.com.
+/// Headers are inserted only when absent so an upstream ingress can override.
+async fn set_security_headers(req: Request, next: Next) -> Response {
+    const CSP: &str = "default-src 'self'; \
+         script-src 'self'; \
+         style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
+         font-src 'self' https://fonts.gstatic.com; \
+         img-src 'self' data:; \
+         connect-src 'self'; \
+         frame-ancestors 'none'; \
+         base-uri 'self'; \
+         form-action 'self'; \
+         object-src 'none'";
+
+    let mut res = next.run(req).await;
+    let h = res.headers_mut();
+    let set = |h: &mut axum::http::HeaderMap, name: HeaderName, value: &'static str| {
+        if !h.contains_key(&name) {
+            h.insert(name, HeaderValue::from_static(value));
+        }
+    };
+    set(h, header::CONTENT_SECURITY_POLICY, CSP);
+    set(h, header::X_CONTENT_TYPE_OPTIONS, "nosniff");
+    set(h, header::X_FRAME_OPTIONS, "DENY");
+    set(h, header::REFERRER_POLICY, "strict-origin-when-cross-origin");
+    set(
+        h,
+        HeaderName::from_static("permissions-policy"),
+        "camera=(), microphone=(), geolocation=()",
+    );
+    res
+}
+
 #[tokio::main]
 async fn main() {
     // Build our application with a route
     let app = Router::new()
-        .route("/", get(|| async { Html(INDEX_HTML) }));
+        .route("/", get(|| async { Html(INDEX_HTML) }))
+        .layer(middleware::from_fn(set_security_headers));
 
     // Define the port (using 30005 to avoid collision)
     let addr = SocketAddr::from(([0, 0, 0, 0], 30005));


### PR DESCRIPTION
The portal launchpad served HTML with **no Content-Security-Policy**. Adds a `set_security_headers` axum middleware to `packages/asgard-portal`.

## CSP — strictest of the UI set (the launchpad has no JavaScript)
- `script-src 'self'` — **no `'unsafe-inline'`** (page has 0 `<script>` tags)
- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` — inline `<style>` block + Google Fonts
- `font-src 'self' https://fonts.gstatic.com`, `img-src 'self' data:`
- `object-src 'none'`, `frame-ancestors 'none'`, `base-uri`/`form-action 'self'`, X-Frame-Options DENY, nosniff, Referrer-Policy, Permissions-Policy

## Verified
Built + run locally + deployed `asgard-portal:csp-20260618`: page serves 200, CSP live on cluster.

## Related (this session)
Also fixed the portal's **Service port drift** (live svc was `80→3000`; app/ingress/manifest all expect `30005`) via `kubectl patch` — live now matches the repo manifest, restoring connectivity (was HTTP 000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)