### PR TITLE
fix(ingress): baseline security response headers (Asgard#99 PR-1)

### DIFF
--- a/k8s/04-security/ingress.yaml
+++ b/k8s/04-security/ingress.yaml
@@ -9,6 +9,19 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: "asgard-ca-issuer"
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    # Security response headers (Odin 2026-06-14 scan, Asgard#99 — PR-1).
+    # Applied at the single shared ingress so every fronted host gets them at once.
+    # Conservative set only: no source-restricting CSP (default-src/script-src),
+    # which would break inline-script/style UIs (portal, mimir-dashboard) — that
+    # stricter CSP is tracked as a follow-up. `frame-ancestors 'self'` is the
+    # modern anti-clickjacking control and is safe (it restricts framing only).
+    # Requires `allow-snippet-annotations: "true"` on the ingress-nginx controller.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: SAMEORIGIN";
+      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+      more_set_headers "Content-Security-Policy: frame-ancestors 'self'";
+      more_clear_headers "Server";
 spec:
   tls:
     - hosts: ["*.asgard.internal", "portal.asgard.internal", "asgard.internal"]


### PR DESCRIPTION
## What

Adds baseline HTTP **security response headers** at the shared `asgard-ingress`, covering every fronted host in one place (host, bifrost, mimir-dashboard, portal, fenrir, forseti, vault, monitor, sso, …).

Closes the ingress-level slice of the Odin **2026-06-14** scan (`Asgard#99`). The Eir-family slice already landed in #104 at the service level.

## Headers added (`k8s/04-security/ingress.yaml`)
| Header | Addresses |
|---|---|
| `X-Content-Type-Options: nosniff` | MIME sniffing |
| `X-Frame-Options: SAMEORIGIN` + CSP `frame-ancestors 'self'` | clickjacking |
| `Referrer-Policy: strict-origin-when-cross-origin` | referrer leakage |
| `more_clear_headers "Server"` | nginx version leak (`nginx/1.31.1`) |

## Deliberately scoped (safety)
- **No source-restricting CSP** (`default-src` / `script-src`). The portal and mimir-dashboard rely on inline scripts/styles; a strict CSP would blank them. That stricter, `unsafe-inline`-eliminating CSP is a tracked follow-up, not this PR.
- `frame-ancestors 'self'` is framing-only, so it can't break rendering.

## ⚠️ Prerequisite
Uses `nginx.ingress.kubernetes.io/configuration-snippet`, which requires `allow-snippet-annotations: "true"` on the ingress-nginx controller. If snippet annotations are disabled cluster-wide, the equivalent is a controller-level `add-headers` / `custom-response-headers` ConfigMap — happy to switch the approach if reviewers prefer.

## Verify after deploy
```
curl -skI https://host.asgard.internal | grep -iE 'x-frame|x-content|referrer|content-security|server'
```
Expect the four headers present and no version in `Server`. Confirm portal + mimir-dashboard still render.

Part of #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
