### PR TITLE
feat(watchdog): auto-recover with N-tick debounce + stable ~/bin deploy path

### DIFF
--- a/scripts/asgard-watchdog.sh
+++ b/scripts/asgard-watchdog.sh
@@ -25,6 +25,7 @@ REPEAT_EVERY="${REPEAT_EVERY:-12}"        # re-alert every N ticks while degrade
 # the cluster is disruptive; set AUTO_RECOVER=1 to enable. Guards: wedge signal
 # only, at most once per cooldown, alert before + after.
 AUTO_RECOVER="${AUTO_RECOVER:-0}"
+RECOVER_AFTER_TICKS="${RECOVER_AFTER_TICKS:-3}"       # require N consecutive wedge ticks (~15min @5min) before restarting — debounce transient blips
 RECOVER_COOLDOWN="${RECOVER_COOLDOWN:-3600}"          # seconds (max 1 restart/hour)
 RECOVER_STATE="${RECOVER_STATE:-$HOME/.asgard-watchdog.recover}"
 ORBCTL="${ORBCTL:-$(command -v orbctl 2>/dev/null || echo /usr/local/bin/orbctl)}"
@@ -132,12 +133,18 @@ print(json.dumps({"embeds":[{
 }
 
 # Opt-in: restart OrbStack on a sustained runtime wedge (INC-2026-06-15). Only
-# fires on the wedge signal, at most once per cooldown, alerts before + after.
-# No-op unless AUTO_RECOVER=1, so it can't surprise-restart the cluster.
+# fires on the wedge signal, after ≥RECOVER_AFTER_TICKS consecutive degraded
+# ticks (debounce), at most once per cooldown, alerts before + after. No-op
+# unless AUTO_RECOVER=1, so it can't surprise-restart the cluster.
 maybe_auto_recover() {
   [[ "$AUTO_RECOVER" == "1" ]] || return 0
   degraded "$CODE" || return 0
   printf '%s' "$JSON" | grep -qiE 'cluster unreachable|Terminating >1h|sandbox|PLEG|OrbStack' || return 0
+  # debounce: only on a SUSTAINED wedge, not a one-off blip. SINCE is the
+  # consecutive-degraded counter from the state machine above.
+  if (( SINCE < RECOVER_AFTER_TICKS )); then
+    echo "[watchdog] auto-recover armed (wedge ${SINCE}/${RECOVER_AFTER_TICKS} ticks — holding)"; return 0
+  fi
   local last=0 now; [[ -f "$RECOVER_STATE" ]] && last=$(cat "$RECOVER_STATE" 2>/dev/null || echo 0)
   now=$(date +%s)
   if (( now - last < RECOVER_COOLDOWN )); then
@@ -155,9 +162,14 @@ maybe_auto_recover() {
 }
 
 case "$ACTION" in
-  degraded)  echo "[watchdog] OK→DEGRADED (code=$CODE)"; send_alert "degraded"; maybe_auto_recover ;;
-  reminder)  echo "[watchdog] still degraded (${SINCE} ticks)"; send_alert "reminder"; maybe_auto_recover ;;
+  degraded)  echo "[watchdog] OK→DEGRADED (code=$CODE)"; send_alert "degraded" ;;
+  reminder)  echo "[watchdog] still degraded (${SINCE} ticks)"; send_alert "reminder" ;;
   recovered) echo "[watchdog] DEGRADED→RECOVERED"; send_alert "recovered" ;;
   none)      echo "[watchdog] code=$CODE, no state change" ;;
 esac
+
+# Evaluated EVERY tick (not only on alert transitions) so the ≥N-tick debounce
+# can fire mid-streak; its own guards decide whether it actually restarts.
+maybe_auto_recover
+
 exit 0

--- a/scripts/install-watchdog.sh
+++ b/scripts/install-watchdog.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║  install-watchdog — deploy the host health watchdog to a STABLE path  ║
+# ║                                                                       ║
+# ║  Copies asgard-watchdog.sh + asgard-preflight.sh to ~/bin (decoupled  ║
+# ║  from this git checkout, so a branch switch can't swap the live       ║
+# ║  script out from under launchd), installs the launchd agent, and      ║
+# ║  reloads it.                                                          ║
+# ║                                                                       ║
+# ║  Run:  bash install-watchdog.sh        (user-level, no sudo)          ║
+# ║  Re-runnable / idempotent — re-run after editing either script.       ║
+# ║                                                                       ║
+# ║  Host enablement (AUTO_RECOVER, DISCORD_WEBHOOK, …) lives in the       ║
+# ║  gitignored, chmod-600 ~/.asgard-watchdog.env — NOT managed here.     ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BIN="$HOME/bin"
+LABEL="com.asgard.watchdog"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+mkdir -p "$BIN" "$HOME/Library/Logs"
+
+# 1. Deploy the watchdog AND its preflight dependency — they must stay
+#    co-located: asgard-watchdog.sh resolves asgard-preflight.sh from its own
+#    directory ($HERE), so shipping one without the other breaks it.
+install -m 0755 "$HERE/asgard-watchdog.sh"  "$BIN/asgard-watchdog.sh"
+install -m 0755 "$HERE/asgard-preflight.sh" "$BIN/asgard-preflight.sh"
+echo "✓ scripts → $BIN"
+
+# 2. Install + (re)load the launchd agent (points at $BIN, not the git tree).
+install -m 0644 "$HERE/launchd/$LABEL.plist" "$PLIST"
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+echo "✓ launchd agent (re)loaded: $LABEL"
+
+# 3. Smoke test: fire one tick now (RunAtLoad already did, this is belt-and-braces).
+launchctl kickstart "gui/$(id -u)/$LABEL" 2>/dev/null || true
+echo "✓ kicked one tick — check ~/.asgard-watchdog.log and ~/Library/Logs/asgard-watchdog.out.log"

--- a/scripts/launchd/com.asgard.watchdog.plist
+++ b/scripts/launchd/com.asgard.watchdog.plist
@@ -6,14 +6,16 @@
     <string>com.asgard.watchdog</string>
 
     <!-- Host-side health watchdog: runs asgard-preflight every 5 min and alerts
-         to OpenSearch on degradation. Independent of the cluster it watches. -->
+         to OpenSearch on degradation. Independent of the cluster it watches.
+         Runs from a STABLE deploy path (~/bin), NOT the git working tree, so a
+         branch checkout can't swap the live script (deploy: install-watchdog.sh). -->
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/mimir/Developer/Asgard/scripts/asgard-watchdog.sh</string>
+        <string>/Users/mimir/bin/asgard-watchdog.sh</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/mimir/Developer/Asgard/scripts</string>
+    <string>/Users/mimir/bin</string>
 
     <!-- kubectl/curl live in the user's shell PATH; provide a sane default -->
     <key>EnvironmentVariables</key>
@@ -30,8 +32,8 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>/Users/mimir/Developer/Asgard/logs/watchdog-stdout.log</string>
+    <string>/Users/mimir/Library/Logs/asgard-watchdog.out.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/mimir/Developer/Asgard/logs/watchdog-stderr.log</string>
+    <string>/Users/mimir/Library/Logs/asgard-watchdog.err.log</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Why
On **2026-06-24** a PLEG/runtime wedge left the cluster API unreachable for **~7h overnight** (17:21→00:31 UTC) and only self-healed by luck — `asgard-watchdog` *alerts* but never *remediates*. `maybe_auto_recover` (orbctl stop/start on a wedge signal) already existed but was opt-in (`AUTO_RECOVER=0`) and fired on the **very first** degraded tick — too trigger-happy to safely restart the whole cluster.

## What
- Add `RECOVER_AFTER_TICKS` (default **3** ≈ 15 min at the 5-min cadence): require a **sustained** wedge before restarting → debounces transient API blips.
- Move the `maybe_auto_recover` call out of the `degraded`/`reminder` case arms so it runs **every tick** — the ≥N-tick threshold can now fire mid-streak (previously it could only fire at tick 1 or the ~1h reminder).

Existing guards unchanged: wedge-signal regex, `RECOVER_COOLDOWN` (≤1 restart/hr), Discord alert before + after. **No-op unless `AUTO_RECOVER=1`.**

## Host enablement (not in this PR)
Turned on via the gitignored, chmod-600 `~/.asgard-watchdog.env` on Macminimimir: `AUTO_RECOVER=1`, `RECOVER_AFTER_TICKS=3`. Already live (launchd runs the script file directly).

## Verification
Stub preflight + `ORBCTL=/usr/bin/true` (no real restart): **HOLD** at 2/3 ticks → **FIRE** at 3/3 → **cooldown-suppress** on the next tick. Real run against the healthy cluster = `code=0`, no recover attempt.

## Base note
Targets `fix/minio-root-creds-secret`, **not** `main` — the watchdog script was added on that branch (commit `2c8bf84`) and does not exist on `main` (which is 38 commits behind). Basing on `main` would turn this into a whole-file + 38-commit diff. Retarget to `main` once that ops branch merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)