### PR TITLE
fix(ops): restore the launchd jobs that a branch switch silently killed

### DIFF
--- a/scripts/asgard-boot-report.sh
+++ b/scripts/asgard-boot-report.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# asgard-boot-report — fired ONCE per host boot (launchd com.asgard.boot-report,
+# RunAtLoad). Waits for the cluster to come up, takes a FULL census of every
+# Asgard service, and posts a single summary to Discord *as Odin* via the webhook.
+#
+# Why host-side and not inside Odin: the whole point is to report when boot went
+# wrong — and a cluster/Odin-pod that failed to start can't report on itself
+# (same lesson as asgard-watchdog). So this runs on the host, independent of the
+# cluster it watches, and posts under the "Odin 🏛️" identity so it reads as Odin
+# in the channel.
+#
+# "All services, really" = auto-enumerated, NOT a hardcoded list (which drifts):
+#   - every Deployment + StatefulSet across: asgard, asgard-infra, wazuh
+#       · desired>0 & ready==desired → UP
+#       · desired>0 & ready<desired  → DOWN  (a real problem)
+#       · desired==0                 → IDLE  (scaled to 0 on purpose — laminar,
+#                                              llmgoat, redis-infra, … — NOT a fault)
+#   - native host services (not in K8s): Heimdall gateway/MLX/VLM + Syn AppleVision
+#
+# Usage:
+#   ./asgard-boot-report.sh             wait for boot to settle, then post
+#   ./asgard-boot-report.sh --dry-run   compute census + print the message, DON'T post
+#   ./asgard-boot-report.sh --no-wait   skip the settle loop, census now (for testing)
+set -uo pipefail
+
+DRY=0; NOWAIT=0; FORCE=0
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY=1 ;;
+    --no-wait) NOWAIT=1 ;;
+    --force)   FORCE=1 ;;
+  esac
+done
+
+# ── tunables ───────────────────────────────────────────────────────────────
+BOOT_WINDOW="${BOOT_WINDOW:-1800}"    # only treat a run as a real boot if uptime < this (s)
+KUBE_NS="${KUBE_NS:-asgard asgard-infra wazuh}"
+CLUSTER_WAIT="${CLUSTER_WAIT:-600}"   # max seconds to wait for kubectl to reach the cluster
+SETTLE_MAX="${SETTLE_MAX:-900}"       # max seconds to wait for pods to become ready
+POLL="${POLL:-20}"                    # seconds between settle polls
+MIN_WORKLOADS="${MIN_WORKLOADS:-25}"  # don't declare "all up" until we've seen at least this many active workloads (guards against an empty/early cluster reading 0-down)
+KCTL="kubectl --request-timeout=8s"
+
+# Secrets (DISCORD_WEBHOOK) live in the same gitignored, chmod-600 file the
+# watchdog uses. launchd has no shell env, so source it explicitly.
+[[ -f "$HOME/.asgard-watchdog.env" ]] && source "$HOME/.asgard-watchdog.env"
+DISCORD_WEBHOOK="${DISCORD_WEBHOOK:-}"
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+HOST="$(scutil --get LocalHostName 2>/dev/null || hostname)"
+START_EPOCH="$(date +%s)"
+
+# ── fresh-boot guard ─────────────────────────────────────────────────────────
+# launchd RunAtLoad fires every time the agent is loaded — at real boot/login AND
+# on any manual `launchctl bootstrap`. We only want to report "หาก start server
+# ใหม่" = a genuine boot. Gate on system uptime: if the box has been up longer
+# than BOOT_WINDOW, this load is NOT a fresh boot → do nothing (so re-registering
+# the agent never spams the channel). --force / --no-wait / --dry-run bypass it.
+# format: "{ sec = 1781358055, usec = 708862 } …" — $4 is "sec," (note: "usec"
+# also contains "sec", so a greedy regex grabs the wrong one — use the field).
+BOOTSEC="$(sysctl -n kern.boottime 2>/dev/null | awk '{print $4}' | tr -d ',')"
+if [[ "$BOOTSEC" =~ ^[0-9]+$ ]]; then
+  UPTIME=$(( START_EPOCH - BOOTSEC ))
+else
+  UPTIME=0
+fi
+if (( DRY == 0 && NOWAIT == 0 && FORCE == 0 )) && (( UPTIME > BOOT_WINDOW )); then
+  echo "[boot-report] uptime ${UPTIME}s > ${BOOT_WINDOW}s — not a fresh boot, skipping (use --force to override)"
+  exit 0
+fi
+
+# ── host (native) service probes ─────────────────────────────────────────────
+http_up() { curl -sf --max-time 4 "$1" >/dev/null 2>&1; }
+tcp_up()  { (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3>&-; return 0; } || return 1; }
+launchd_up() { launchctl list "$1" 2>/dev/null | grep -q '"PID"'; }
+
+# echoes: "<name>\t<up|down>" per host service
+host_census() {
+  local -a checks=(
+    "Heimdall gateway:8080|http|http://localhost:8080/health"
+    "Heimdall MLX:8081|http|http://localhost:8081/v1/models"
+    "Heimdall VLM-q4:8082|tcp|8082"
+    "Heimdall VLM-q8:8083|tcp|8083"
+    "Heimdall VLM-qwen2:8087|tcp|8087"
+    "Syn AppleVision|launchd|com.asgard.syn-applevision"
+  )
+  local c name kind arg
+  for c in "${checks[@]}"; do
+    name="${c%%|*}"; kind="$(cut -d'|' -f2 <<<"$c")"; arg="${c##*|}"
+    case "$kind" in
+      http)    http_up "$arg"    && printf '%s\tup\n' "$name" || printf '%s\tdown\n' "$name" ;;
+      tcp)     tcp_up  "$arg"    && printf '%s\tup\n' "$name" || printf '%s\tdown\n' "$name" ;;
+      launchd) launchd_up "$arg" && printf '%s\tup\n' "$name" || printf '%s\tdown\n' "$name" ;;
+    esac
+  done
+}
+
+# ── k8s census ────────────────────────────────────────────────────────────────
+# echoes one line per workload: "<ns>\t<kind>\t<name>\t<state>\t<ready>/<desired>"
+# state ∈ up|down|idle. Auto-discovers every Deployment + StatefulSet.
+k8s_census() {
+  local ns line kind name desired ready state
+  for ns in $KUBE_NS; do
+    while IFS=$'\t' read -r kind name desired ready; do
+      [[ -z "$name" ]] && continue
+      [[ -z "$desired" ]] && desired=0
+      [[ -z "$ready" ]] && ready=0
+      if   (( desired == 0 ));        then state="idle"
+      elif (( ready >= desired ));    then state="up"
+      else                                 state="down"; fi
+      printf '%s\t%s\t%s\t%s\t%d/%d\n' "$ns" "$kind" "$name" "$state" "$ready" "$desired"
+    done < <($KCTL get deploy,statefulset -n "$ns" \
+        -o jsonpath='{range .items[*]}{.kind}{"\t"}{.metadata.name}{"\t"}{.spec.replicas}{"\t"}{.status.readyReplicas}{"\n"}{end}' 2>/dev/null)
+  done
+}
+
+# down-count from a census blob (k8s + host), for the settle loop
+count_down() { grep -c $'\tdown\t\|\tdown$' <<<"$1" 2>/dev/null || true; }
+
+cluster_reachable() { $KCTL get ns >/dev/null 2>&1; }
+
+# ── 1. wait for the cluster to be reachable ──────────────────────────────────
+CLUSTER_OK=0
+if (( NOWAIT == 1 )); then
+  cluster_reachable && CLUSTER_OK=1
+else
+  while (( $(date +%s) - START_EPOCH < CLUSTER_WAIT )); do
+    if cluster_reachable; then CLUSTER_OK=1; break; fi
+    sleep "$POLL"
+  done
+fi
+
+# ── 2. settle loop: wait until nothing is DOWN (or SETTLE_MAX elapses) ────────
+K8S=""; HOSTC=""
+if (( CLUSTER_OK == 1 )); then
+  while :; do
+    K8S="$(k8s_census)"
+    HOSTC="$(host_census)"
+    active_total=$(grep -cE $'\tup\t|\tdown\t' <<<"$K8S")
+    k8s_down=$(grep -c $'\tdown\t' <<<"$K8S" || true)
+    host_down=$(grep -c $'\tdown$' <<<"$HOSTC" || true)
+    elapsed=$(( $(date +%s) - START_EPOCH ))
+    if (( NOWAIT == 1 )); then break; fi
+    # settled when nothing is down AND we've actually seen the cluster populate
+    if (( k8s_down == 0 && host_down == 0 && active_total >= MIN_WORKLOADS )); then break; fi
+    if (( elapsed >= SETTLE_MAX )); then break; fi
+    sleep "$POLL"
+  done
+else
+  # cluster never came up — still probe host services so we report what we can
+  HOSTC="$(host_census)"
+fi
+
+ELAPSED=$(( $(date +%s) - START_EPOCH ))
+
+# ── 3. tally ─────────────────────────────────────────────────────────────────
+UP_LIST="$(grep $'\tup\t'   <<<"$K8S" 2>/dev/null || true)"
+DOWN_LIST="$(grep $'\tdown\t' <<<"$K8S" 2>/dev/null || true)"
+IDLE_LIST="$(grep $'\tidle\t' <<<"$K8S" 2>/dev/null || true)"
+HOST_UP_LIST="$(grep $'\tup$'   <<<"$HOSTC" 2>/dev/null || true)"
+HOST_DOWN_LIST="$(grep $'\tdown$' <<<"$HOSTC" 2>/dev/null || true)"
+
+cnt() { [[ -z "$1" ]] && echo 0 || grep -c . <<<"$1"; }
+UP_N=$(cnt "$UP_LIST"); DOWN_N=$(cnt "$DOWN_LIST"); IDLE_N=$(cnt "$IDLE_LIST")
+HOST_UP_N=$(cnt "$HOST_UP_LIST"); HOST_DOWN_N=$(cnt "$HOST_DOWN_LIST")
+ACTIVE_N=$(( UP_N + DOWN_N ))
+HOST_N=$(( HOST_UP_N + HOST_DOWN_N ))
+TOTAL_DOWN=$(( DOWN_N + HOST_DOWN_N ))
+
+# friendly down lines: "ns/name (ready/desired)" and host "name"
+fmt_down_k8s() { awk -F'\t' '{print "• "$1"/"$3" ("$5")"}' <<<"$1"; }
+fmt_down_host() { awk -F'\t' '{print "• "$1" (host)"}' <<<"$1"; }
+DOWN_PRETTY="$( [[ -n "$DOWN_LIST" ]] && fmt_down_k8s "$DOWN_LIST"; [[ -n "$HOST_DOWN_LIST" ]] && fmt_down_host "$HOST_DOWN_LIST" )"
+
+# ── 4. verdict ────────────────────────────────────────────────────────────────
+if (( CLUSTER_OK == 0 )); then
+  KIND="cluster-down"; STATUS="🔴 Asgard boot — Kubernetes did not come up"
+elif (( TOTAL_DOWN == 0 )); then
+  KIND="ok"; STATUS="🟢 Asgard boot complete — all services up"
+else
+  KIND="degraded"; STATUS="🔴 Asgard boot — ${TOTAL_DOWN} service(s) did not start"
+fi
+
+# ── 5. compose Discord payload (as Odin) ──────────────────────────────────────
+PAYLOAD="$(KIND="$KIND" STATUS="$STATUS" UP_N="$UP_N" ACTIVE_N="$ACTIVE_N" \
+  IDLE_N="$IDLE_N" HOST_UP_N="$HOST_UP_N" HOST_N="$HOST_N" TOTAL_DOWN="$TOTAL_DOWN" \
+  DOWN_PRETTY="$DOWN_PRETTY" CLUSTER_OK="$CLUSTER_OK" ELAPSED="$ELAPSED" \
+  HOSTN="$HOST" NOW="$NOW" python3 -c '
+import json, os
+kind = os.environ["KIND"]
+color = {"ok": 3066993, "degraded": 15158332, "cluster-down": 15158332}.get(kind, 9807270)
+down = os.environ["DOWN_PRETTY"].strip()
+cluster_ok = os.environ["CLUSTER_OK"] == "1"
+if kind == "ok":
+    desc = "✅ Every Asgard service with desired replicas came up cleanly."
+elif not cluster_ok:
+    desc = "❌ kubectl could not reach the cluster within the boot window (OrbStack / K3s not up?).\n_All K8s service states unknown — only host services were probed._"
+else:
+    lines = down.split("\n") if down else []
+    shown = lines[:25]
+    desc = "**Did not start:**\n" + "\n".join(shown)
+    if len(lines) > 25:
+        desc += f"\n…and {len(lines)-25} more"
+desc = desc[:4000]
+up_n = os.environ["UP_N"]; active_n = os.environ["ACTIVE_N"]
+host_up = os.environ["HOST_UP_N"]; host_n = os.environ["HOST_N"]
+fields = [
+    {"name": "K8s services", "value": f"{up_n}/{active_n} up", "inline": True},
+    {"name": "Host services", "value": f"{host_up}/{host_n} up", "inline": True},
+    {"name": "Idle (scaled-0)", "value": os.environ["IDLE_N"], "inline": True},
+    {"name": "Down", "value": os.environ["TOTAL_DOWN"], "inline": True},
+    {"name": "Settle time", "value": os.environ["ELAPSED"] + "s", "inline": True},
+    {"name": "Host", "value": os.environ["HOSTN"], "inline": True},
+]
+print(json.dumps({
+    "username": "Odin 🏛️",
+    "embeds": [{
+        "title": os.environ["STATUS"],
+        "description": desc,
+        "color": color,
+        "fields": fields,
+        "footer": {"text": "asgard-boot-report • " + os.environ["NOW"]},
+    }],
+}))')"
+
+# ── 6. emit / post ────────────────────────────────────────────────────────────
+if (( DRY == 1 )); then
+  echo "── DRY RUN (not posting) ───────────────────────────────"
+  echo "verdict: $STATUS   (settle ${ELAPSED}s, cluster_ok=$CLUSTER_OK)"
+  echo "K8s: ${UP_N}/${ACTIVE_N} up, ${IDLE_N} idle, ${DOWN_N} down   Host: ${HOST_UP_N}/${HOST_N} up"
+  [[ -n "$DOWN_PRETTY" ]] && { echo "down:"; echo "$DOWN_PRETTY"; }
+  echo "── payload ─────────────────────────────────────────────"
+  echo "$PAYLOAD" | python3 -m json.tool 2>/dev/null || echo "$PAYLOAD"
+  exit 0
+fi
+
+if [[ -z "$DISCORD_WEBHOOK" ]]; then
+  echo "[boot-report] ERROR: DISCORD_WEBHOOK not set (~/.asgard-watchdog.env) — cannot post" >&2
+  exit 1
+fi
+
+if curl -s --max-time 15 -H 'Content-Type: application/json' -d "$PAYLOAD" "$DISCORD_WEBHOOK" >/dev/null 2>&1; then
+  echo "[boot-report] posted to Discord as Odin ($KIND): ${UP_N}/${ACTIVE_N} k8s up, ${HOST_UP_N}/${HOST_N} host up, ${TOTAL_DOWN} down (settle ${ELAPSED}s)"
+else
+  echo "[boot-report] WARN: Discord webhook post failed" >&2
+  exit 1
+fi

--- a/scripts/asgard-build-guard.sh
+++ b/scripts/asgard-build-guard.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# asgard-build-guard — refuse heavy local docker builds while the host/cluster is
+# in no shape for them. Two incidents trace back to building at the wrong time:
+#   INC-2026-06-12: an 18GB build cache filled the node disk → DiskPressure →
+#                   cluster-wide eviction.
+#   INC-2026-06-15: builds during an already-flapping runtime helped tip it into
+#                   a full containerd wedge.
+#
+# Use as a gate before a build:
+#   asgard-build-guard.sh && GH_TOKEN=$(gh auth token) DOCKER_BUILDKIT=1 docker build ...
+# Emergency override:  FORCE=1 asgard-build-guard.sh
+#
+# Exit 0 = safe to build, non-zero = blocked (reason on stderr).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PREFLIGHT="${PREFLIGHT:-$HERE/asgard-preflight.sh}"
+MIN_FREE_GB="${MIN_FREE_GB:-15}"
+
+if [[ "${FORCE:-0}" == "1" ]]; then
+  echo "[build-guard] FORCE=1 — skipping checks" >&2
+  exit 0
+fi
+
+# 1. Disk headroom on / (build cache + image layers land here).
+AVAIL_GB=$(df -g / 2>/dev/null | awk 'NR==2{print $4}')
+if [[ -n "${AVAIL_GB:-}" && "$AVAIL_GB" -lt "$MIN_FREE_GB" ]]; then
+  echo "[build-guard] BLOCK: only ${AVAIL_GB}GB free on / (need >=${MIN_FREE_GB}GB)." >&2
+  echo "             reclaim:  docker builder prune -f   (NOT image prune)" >&2
+  exit 1
+fi
+
+# 2. Cluster health — don't add load to a degraded runtime.
+if [[ -x "$PREFLIGHT" ]]; then
+  "$PREFLIGHT" --json >/tmp/.build-guard-preflight.json 2>/dev/null || true
+  CODE=$(python3 -c 'import json;print(json.load(open("/tmp/.build-guard-preflight.json")).get("code",0))' 2>/dev/null || echo 0)
+  if [[ "${CODE:-0}" -ge 2 ]]; then
+    echo "[build-guard] BLOCK: cluster is FAIL — a heavy build now risks tipping it." >&2
+    python3 -c 'import json;d=json.load(open("/tmp/.build-guard-preflight.json"));[print("             •",f) for f in d.get("fail",[])[:6]]' 2>/dev/null || true
+    echo "             override with FORCE=1 if you must build anyway." >&2
+    exit 1
+  fi
+fi
+
+echo "[build-guard] OK — ${AVAIL_GB:-?}GB free, cluster code=${CODE:-0}. Safe to build."
+exit 0

--- a/scripts/asgard-ca-expiry-check.sh
+++ b/scripts/asgard-ca-expiry-check.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║  asgard-ca-expiry-check — SAFETY NET (no root needed)                 ║
+# ║                                                                      ║
+# ║  Independent watchdog for the Asgard root CA trust anchor. Even if    ║
+# ║  the root LaunchDaemon (com.asgard.ca-distributor) is never installed ║
+# ║  or dies, this SCREAMS before the trust store silently expires — the  ║
+# ║  exact failure that broke *.asgard.internal on 2026-07-08.           ║
+# ║                                                                      ║
+# ║  Checks, read-only, as the user (no keychain writes → no sudo):      ║
+# ║   1. the newest Asgard root in the System keychain — days until it   ║
+# ║      expires (alert if < THRESHOLD or already expired)               ║
+# ║   2. DRIFT: does the keychain actually trust the CURRENT cluster     ║
+# ║      root fingerprint? (catches key-preserving re-issues not synced) ║
+# ║                                                                      ║
+# ║  Alerts to Discord (reuses ~/.asgard-watchdog.env) + logs + exit≠0.  ║
+# ║  Runs via com.asgard.ca-expiry-watch (user LaunchAgent, daily).      ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export KUBECONFIG="${KUBECONFIG:-/Users/mimir/.kube/config}"
+
+CN="Asgard Private Enterprise Root CA"
+KEYCHAIN="/Library/Keychains/System.keychain"
+THRESHOLD_DAYS="${ASGARD_CA_WARN_DAYS:-30}"
+NS="cert-manager"; SECRET="asgard-root-secret"
+LOG_DIR="/Users/mimir/Developer/Asgard/logs"; LOG="$LOG_DIR/ca-expiry-check.log"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
+[[ -f "$HOME/.asgard-watchdog.env" ]] && source "$HOME/.asgard-watchdog.env"
+DISCORD_WEBHOOK="${DISCORD_WEBHOOK:-}"
+
+log()    { echo "$(/bin/date -u +%FT%TZ) $*" | tee -a "$LOG" >&2; }
+notify() { [[ -z "$DISCORD_WEBHOOK" ]] && return 0
+  curl -s --max-time 10 -H 'Content-Type: application/json' \
+    -d "{\"username\":\"Heimdall\",\"content\":\"🔐 CA-watch: $1\"}" "$DISCORD_WEBHOOK" >/dev/null 2>&1 || true; }
+fp256()  { openssl x509 -in "$1" -noout -fingerprint -sha256 2>/dev/null | sed 's/.*=//; s/://g'; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+PROBLEM=0
+
+# ── 1. Newest Asgard root in the System keychain → days to expiry ─────────
+security find-certificate -a -c "$CN" -p "$KEYCHAIN" 2>/dev/null > "$TMP/kc.pem" || true
+if [[ ! -s "$TMP/kc.pem" ]]; then
+  log "CRITICAL: no '$CN' found in System keychain — *.asgard.internal is UNTRUSTED"
+  notify "❌ no Asgard root in System keychain — HTTPS to *.asgard.internal is broken. Install: sudo bash ~/Developer/Asgard/scripts/install-ca-autorenew.sh"
+  exit 2
+fi
+awk -v d="$TMP" 'BEGIN{n=0} /-----BEGIN CERTIFICATE-----/{n++} {print >> (d"/a-"n".pem")}' "$TMP/kc.pem"
+NOW=$(/bin/date -u +%s); BEST_LEFT=-999999; BEST_END=""; BEST_FP=""
+KC_FPS=""
+for f in "$TMP"/a-*.pem; do
+  [[ -s "$f" ]] || continue
+  KC_FPS="$KC_FPS $(fp256 "$f")"
+  end="$(openssl x509 -in "$f" -noout -enddate 2>/dev/null | sed 's/.*=//')"
+  [[ -z "$end" ]] && continue
+  end_s=$(/bin/date -j -f "%b %e %T %Y %Z" "$end" +%s 2>/dev/null || echo 0)
+  left=$(( (end_s - NOW) / 86400 ))
+  if (( left > BEST_LEFT )); then BEST_LEFT=$left; BEST_END="$end"; BEST_FP="$(fp256 "$f")"; fi
+done
+log "keychain newest Asgard root: fp=${BEST_FP:0:16}… expires '$BEST_END' (${BEST_LEFT}d left)"
+if (( BEST_LEFT < 0 )); then
+  log "CRITICAL: keychain Asgard root EXPIRED ${BEST_LEFT#-}d ago"
+  notify "❌ System-keychain Asgard root EXPIRED ($BEST_END). *.asgard.internal HTTPS broken. Fix: sudo bash ~/Developer/Asgard/scripts/install-ca-autorenew.sh"
+  PROBLEM=2
+elif (( BEST_LEFT < THRESHOLD_DAYS )); then
+  log "WARN: keychain Asgard root expires in ${BEST_LEFT}d (< ${THRESHOLD_DAYS}d)"
+  notify "⚠️ System-keychain Asgard root expires in ${BEST_LEFT}d ($BEST_END). Ensure com.asgard.ca-distributor is running (it auto-syncs re-issues)."
+  PROBLEM=1
+fi
+
+# ── 2. TRUST: is the newest Asgard root actually a TRUSTED anchor? ────────
+# A cert can be PRESENT in the keychain yet carry no trust setting (e.g. a
+# launchd daemon's `add-trusted-cert -d` fails "no user interaction possible").
+# macOS then rejects it (CSSMERR_TP_NOT_TRUSTED) — present ≠ trusted.
+if security dump-trust-settings -d 2>/dev/null | grep -qi "asgard"; then
+  log "OK: Asgard root has an admin trust setting (trusted anchor)"
+else
+  log "CRITICAL: Asgard root is PRESENT but has NO admin trust setting — macOS will reject *.asgard.internal"
+  notify "❌ Asgard root present but NOT trusted (no admin trust setting). Fix interactively: sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /usr/local/share/asgard/ca-dist/asgard-root-ca.crt"
+  PROBLEM=2
+fi
+
+# ── 3. DRIFT: does the keychain hold the CURRENT cluster root? ────────────
+kubectl get secret "$SECRET" -n "$NS" -o jsonpath='{.data.ca\.crt}' 2>/dev/null | base64 -d > "$TMP/live.crt" 2>/dev/null || true
+[[ -s "$TMP/live.crt" ]] || kubectl get secret "$SECRET" -n "$NS" -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d > "$TMP/live.crt" 2>/dev/null || true
+if [[ -s "$TMP/live.crt" ]] && openssl x509 -in "$TMP/live.crt" -noout >/dev/null 2>&1; then
+  LIVE_FP="$(fp256 "$TMP/live.crt")"
+  if [[ " $KC_FPS " == *" $LIVE_FP "* ]]; then
+    log "OK: keychain holds the live cluster root ($LIVE_FP)"
+  else
+    log "DRIFT: cluster root fp=$LIVE_FP is NOT in the keychain — a re-issue was not distributed"
+    notify "⚠️ Keychain has DRIFTED from the cluster root (re-issue not synced). Run: sudo launchctl kickstart -k system/com.asgard.ca-distributor  (then re-grant trust interactively — see fix above)"
+    PROBLEM=$(( PROBLEM > 1 ? PROBLEM : 1 ))
+  fi
+else
+  log "note: could not reach cluster to compare (kubectl/OrbStack down) — skipped drift check"
+fi
+
+(( PROBLEM == 0 )) && log "OK: Asgard root trust healthy (${BEST_LEFT}d headroom)"
+exit "$PROBLEM"

--- a/scripts/asgard-deploy-check.sh
+++ b/scripts/asgard-deploy-check.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# asgard-deploy-check — pre-build/redeploy guard against VERSION REGRESSION.
+# Complements asgard-build-guard.sh (which guards host disk / memory / cluster
+# health) with the code↔DB↔branch version invariants. The two regressions this
+# catches — both hit in real incidents:
+#   1. sqlx MIGRATION DRIFT — the live DB has migrations applied that the build
+#      does NOT embed → the strict migrator PANICS on boot → CrashLoop.
+#      (clean-main mimir-api, 2026-06-13.)
+#   2. STALE BUILD — the build branch is behind origin/main → you ship old code
+#      or lose already-merged features. (dashboard lost the Explorer page.)
+# Also surfaces the current deployed image (for rollback) + rollout safety.
+#
+# Read-only. Exit: 0 = OK, 1 = WARN (look before you leap), 2 = FAIL (do NOT deploy).
+#
+# Usage:   asgard-deploy-check.sh [deploy-name]            # default: mimir-api
+#   env:   REPO       (default ~/Developer/Mimir)
+#          BRANCH     (default: current checkout branch)
+#          NS         (default: asgard)            — namespace of the deploy
+#          MIG_DIR    (default: ro-ai-bridge/mimir-core-ai/migrations) — "" to skip
+#          DB_NS DB_DEPLOY DB DB_USER DB_PASS      (default: asgard-infra mariadb mimir root root)
+set -uo pipefail
+SVC="${1:-mimir-api}"
+REPO="${REPO:-$HOME/Developer/Mimir}"
+NS="${NS:-asgard}"
+MIG_DIR="${MIG_DIR:-ro-ai-bridge/mimir-core-ai/migrations}"
+DB_NS="${DB_NS:-asgard-infra}"; DB_DEPLOY="${DB_DEPLOY:-mariadb}"; DB="${DB:-mimir}"
+DB_USER="${DB_USER:-root}"; DB_PASS="${DB_PASS:-root}"
+RC=0; warn(){ echo "  ⚠️  $*"; [ "$RC" -lt 1 ] && RC=1; }; fail(){ echo "  ❌ $*"; RC=2; }; ok(){ echo "  ✓ $*"; }
+
+echo "▶ asgard-deploy-check: $SVC  (repo=$REPO ns=$NS)"
+
+# ── 1. build source: right branch, clean tree, not behind main ──────────────
+echo "1) build source"
+if git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  cd "$REPO" || exit 3
+  BR="${BRANCH:-$(git branch --show-current)}"; [ -z "$BR" ] && BR="(detached $(git rev-parse --short HEAD))"
+  echo "   branch: $BR"
+  [ -n "$(git status --porcelain)" ] && warn "working tree DIRTY — docker build snapshots the dir; uncommitted/other-session edits will leak into the image. Commit/stash first." || ok "working tree clean"
+  git fetch origin main --quiet 2>/dev/null
+  BEHIND=$(git rev-list --count "HEAD..origin/main" 2>/dev/null || echo "?")
+  AHEAD=$(git rev-list --count "origin/main..HEAD" 2>/dev/null || echo "?")
+  if [ "${BEHIND:-0}" != "0" ] && [ "$BEHIND" != "?" ]; then
+    warn "branch is $BEHIND commits BEHIND origin/main → risk of shipping stale code / losing merged features. Merge main first, or build from main."
+  else ok "up to date with origin/main (ahead $AHEAD)"; fi
+else warn "REPO not a git repo: $REPO"; fi
+
+# ── 2. MIGRATION DRIFT (the boot-panic killer) ──────────────────────────────
+echo "2) sqlx migration drift ($MIG_DIR vs $DB_NS/$DB)"
+if [ -n "$MIG_DIR" ] && [ -d "$REPO/$MIG_DIR" ]; then
+  # versions the build will EMBED (on-disk = exactly what docker build copies)
+  ls "$REPO/$MIG_DIR"/*.sql 2>/dev/null | sed -E 's#.*/([0-9]+)_.*#\1#' | grep -E '^[0-9]+$' | LC_ALL=C sort -u > /tmp/.dc_embed
+  # versions APPLIED in the live DB
+  if kubectl -n "$DB_NS" exec -i "deploy/$DB_DEPLOY" -- mariadb -u"$DB_USER" -p"$DB_PASS" -N "$DB" \
+       -e "SELECT version FROM _sqlx_migrations" 2>/dev/null | LC_ALL=C sort -u > /tmp/.dc_applied && [ -s /tmp/.dc_applied ]; then
+    MISSING=$(comm -23 /tmp/.dc_applied /tmp/.dc_embed)   # applied ∉ build → PANIC
+    PENDING=$(comm -13 /tmp/.dc_applied /tmp/.dc_embed)   # build ∉ applied → run on boot
+    if [ -n "$MISSING" ]; then
+      fail "DB has $(echo "$MISSING"|grep -c .) migration(s) the build does NOT embed → mimir-api will PANIC on boot (sqlx strict). Land them to this branch first:"
+      echo "$MISSING" | sed 's/^/        applied-not-in-build: /'
+    else ok "every applied migration is embedded (no boot-panic risk)"; fi
+    if [ -n "$PENDING" ]; then
+      warn "$(echo "$PENDING"|grep -c .) migration(s) will RUN on boot (not yet applied) → BACKUP THE DB FIRST + review for conflicts:"
+      echo "$PENDING" | sed 's/^/        pending: /'
+    else ok "0 pending — boot runs no migration (zero DB mutation)"; fi
+  else warn "could not read _sqlx_migrations from $DB_NS/$DB_DEPLOY — verify manually"; fi
+else echo "   (skipped — MIG_DIR empty or absent; non-sqlx service)"; fi
+
+# ── 3. rollback readiness + rollout safety ──────────────────────────────────
+echo "3) rollback + rollout safety"
+IMG=$(kubectl -n "$NS" get deploy "$SVC" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+PP=$(kubectl -n "$NS" get deploy "$SVC" -o jsonpath='{.spec.template.spec.containers[0].imagePullPolicy}' 2>/dev/null)
+RP=$(kubectl -n "$NS" get deploy "$SVC" -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.path}' 2>/dev/null)
+MU=$(kubectl -n "$NS" get deploy "$SVC" -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}' 2>/dev/null)
+if [ -n "$IMG" ]; then
+  ok "current image (roll back to this if the new one fails): $IMG   [pullPolicy=$PP]"
+  echo "        rollback: kubectl -n $NS set image deploy/$SVC $SVC=$IMG"
+  [ "$PP" = "Never" ] && echo "        ↳ pullPolicy=Never ⇒ build a LOCAL image with a DISTINCT tag (don't overwrite the running tag in place)."
+  [ -n "$RP" ] && ok "readinessProbe=$RP, maxUnavailable=$MU → a crashlooping new pod will NOT drop service (rolls back to old pod)." \
+                || warn "NO readinessProbe → a broken new pod could take traffic. Add one before relying on rolling updates."
+else warn "deploy $SVC not found in ns $NS"; fi
+
+echo "── verdict: $([ $RC -eq 0 ] && echo OK || ([ $RC -eq 1 ] && echo WARN || echo 'FAIL — do not deploy'))  (also run asgard-build-guard.sh for host/disk/cluster)"
+exit $RC

--- a/scripts/asgard-preflight.sh
+++ b/scripts/asgard-preflight.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# asgard-preflight — read-only health check for the invariants that the
+# 2026-06-12 MariaDB incident exposed (and that health.sh does NOT cover).
+#
+# health.sh checks HTTP liveness of services. This checks the INFRA invariants
+# whose silent violation caused / hid that incident:
+#   - no PVC stuck Terminating  (the root cause signal)
+#   - no pods wedged Pending / ImagePull* / CrashLoop  (Odin + MariaDB were here)
+#   - stateful workloads actually have a Running pod    (MariaDB had none)
+#   - host memory headroom                              (kernel-panic guard)
+#   - key host services reachable                       (Heimdall :8080/:8081)
+#   - DB backups are fresh                              (a stale backup is a
+#                                                        silent failure too)
+#
+# Read-only: no kubectl mutation, no service restart. Safe to run anytime, and
+# it is the body of asgard-watchdog.sh.
+#
+# Exit codes:  0 = OK   1 = WARN (degraded)   2 = FAIL (critical)
+#
+# Usage:
+#   ./asgard-preflight.sh            human output
+#   ./asgard-preflight.sh --json     machine output (for the watchdog)
+set -uo pipefail
+
+JSON=0
+[[ "${1:-}" == "--json" ]] && JSON=1
+
+# Tunables
+MIN_FREE_GB="${MIN_FREE_GB:-8}"
+BACKUP_MAX_AGE_DAYS="${BACKUP_MAX_AGE_DAYS:-3}"
+KUBE_NS="${KUBE_NS:-asgard asgard-infra wazuh}"
+KCTL="kubectl --request-timeout=8s"
+T7_BASE="${T7_BASE:-/Volumes/T7 Shield}"   # quoted everywhere (path has a space)
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YEL='\033[1;33m'; NC='\033[0m'
+FAILS=(); WARNS=(); OKS=()
+ok()   { OKS+=("$1");   [[ $JSON -eq 0 ]] && echo -e "  ${GREEN}✅ $1${NC}"; }
+warn() { WARNS+=("$1"); [[ $JSON -eq 0 ]] && echo -e "  ${YEL}⚠️  $1${NC}"; }
+fail() { FAILS+=("$1"); [[ $JSON -eq 0 ]] && echo -e "  ${RED}❌ $1${NC}"; }
+
+section() { [[ $JSON -eq 0 ]] && echo -e "\n$1"; }
+
+# ── 1. host memory headroom ───────────────────────────────────────────────
+section "🧠 Host memory"
+FREE=$(vm_stat 2>/dev/null | awk '/page size/{ps=$8} /Pages free/{gsub(/\./,"",$3);f=$3} /Pages inactive/{gsub(/\./,"",$3);i=$3} END{printf "%d",(f+i)*ps/1073741824}')
+if [[ -z "$FREE" ]]; then warn "memory: could not read vm_stat"
+elif (( FREE < MIN_FREE_GB )); then fail "memory headroom ${FREE}GB < ${MIN_FREE_GB}GB"
+else ok "memory headroom ${FREE}GB"; fi
+
+# ── 2. kubernetes reachable? ──────────────────────────────────────────────
+section "☸️  Kubernetes"
+if ! $KCTL get ns >/dev/null 2>&1; then
+  fail "cluster unreachable (OrbStack/K3s down?) — skipping K8s checks"
+else
+  ok "cluster reachable"
+
+  # 2a. PVCs stuck Terminating — THE incident root-cause signal
+  TERM_PVC=$($KCTL get pvc -A --no-headers 2>/dev/null | awk '$3=="Terminating"{print $1"/"$2}')
+  if [[ -n "$TERM_PVC" ]]; then
+    while read -r p; do [[ -n "$p" ]] && fail "PVC stuck Terminating: $p"; done <<< "$TERM_PVC"
+  else ok "no PVC stuck Terminating"; fi
+
+  # 2a2. pods stuck Terminating >1h — the chronic runtime/kubelet wedge signal.
+  # INC-2026-06-15: pods sat Terminating for ~3 days before the acute outage; the
+  # kubelet couldn't create OR destroy sandboxes. Catch it while still chronic.
+  TERM_OLD=$($KCTL get pods -A -o json 2>/dev/null | python3 -c '
+import sys, json, datetime
+now = datetime.datetime.now(datetime.timezone.utc)
+for p in json.load(sys.stdin).get("items", []):
+    dt = p.get("metadata", {}).get("deletionTimestamp")
+    if not dt:
+        continue
+    t = datetime.datetime.fromisoformat(dt.replace("Z", "+00:00"))
+    age = (now - t).total_seconds() / 3600.0
+    if age > 1:
+        print(f"{p[\"metadata\"][\"namespace\"]}/{p[\"metadata\"][\"name\"]} ({age:.1f}h)")
+' 2>/dev/null)
+  if [[ -n "$TERM_OLD" ]]; then
+    while read -r p; do [[ -n "$p" ]] && fail "pod stuck Terminating >1h: $p"; done <<< "$TERM_OLD"
+  else ok "no pod stuck Terminating >1h"; fi
+
+  # 2b. pods wedged (Pending / ImagePull* / CrashLoop / Error) — exclude Completed
+  for ns in $KUBE_NS; do
+    BAD=$($KCTL get pods -n "$ns" --no-headers 2>/dev/null | \
+      awk '$3 ~ /Pending|ImagePullBackOff|ErrImageNeverPull|ErrImagePull|CrashLoopBackOff|Error|Init:Error/ {print $1" ("$3")"}')
+    if [[ -n "$BAD" ]]; then
+      while read -r p; do [[ -n "$p" ]] && fail "pod wedged in $ns: $p"; done <<< "$BAD"
+    fi
+  done
+
+  # 2b2. node resource pressure — INC-2026-06-12 part 2: a 18GB docker build cache
+  # filled the OrbStack node disk → DiskPressure → cluster-wide pod eviction +
+  # kubelet image-GC removed locally-built (unpullable) images. Catch it early.
+  NODE_PRESSURE=$($KCTL get nodes -o jsonpath='{range .items[*]}{range .status.conditions[?(@.status=="True")]}{.type}{"\n"}{end}{end}' 2>/dev/null | grep -E 'DiskPressure|MemoryPressure|PIDPressure')
+  if [[ -n "$NODE_PRESSURE" ]]; then
+    while read -r c; do [[ -n "$c" ]] && fail "node under $c (evictions imminent — check 'docker system df' build cache)"; done <<< "$NODE_PRESSURE"
+  else ok "no node resource pressure"; fi
+
+  # 2c. stateful workloads have a Running pod
+  for sts in "asgard-infra:mariadb"; do
+    ns="${sts%%:*}"; name="${sts##*:}"
+    RUN=$($KCTL get pods -n "$ns" --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -c "$name")
+    if (( RUN < 1 )); then fail "no Running pod for ${name} in ${ns}"; else ok "${name}: ${RUN} Running pod"; fi
+  done
+fi
+
+# ── 3. host services (native, not in cluster) ─────────────────────────────
+section "🖥️  Host services"
+hc() { local n="$1" u="$2"; if curl -sf --max-time 4 "$u" >/dev/null 2>&1; then ok "$n"; else fail "$n unreachable ($u)"; fi; }
+hc "Heimdall gateway :8080" "http://localhost:8080/health"
+# :8081 mlx server has no /health; check the port is listening + model loaded
+if curl -sf --max-time 5 "http://localhost:8081/v1/models" >/dev/null 2>&1; then ok "Heimdall MLX :8081 (model server)"; else warn "Heimdall MLX :8081 not responding /v1/models"; fi
+
+# ── 4. backup freshness ───────────────────────────────────────────────────
+section "💾 Backups (T7)"
+if [[ ! -d "$T7_BASE" ]]; then
+  warn "T7 not mounted — cannot verify backups"
+else
+  NEWEST=$(find "$T7_BASE" -maxdepth 4 -name '*.sql.gz' -type f 2>/dev/null | while IFS= read -r f; do stat -f '%m %N' "$f"; done | sort -rn | head -1)
+  if [[ -z "$NEWEST" ]]; then
+    warn "no *.sql.gz DB backups found on T7"
+  else
+    TS="${NEWEST%% *}"; NOWS=$(date +%s); AGE_D=$(( (NOWS - TS) / 86400 ))
+    if (( AGE_D > BACKUP_MAX_AGE_DAYS )); then warn "newest DB backup is ${AGE_D}d old (> ${BACKUP_MAX_AGE_DAYS}d)"
+    else ok "newest DB backup ${AGE_D}d old"; fi
+  fi
+fi
+
+# ── 5. Nótt HB (prod) — HB engine on Cloud Run (critical), chat/agents on Mac ─
+# De-SPOF'd 2026-07-10: prod HB compute (/analyze) is served by the GCP Cloud Run engine
+# (nott-engine); /chat + Sleep-Expert agents stay on the Mac (local-LLM).
+# LOCKED DOWN 2026-07-10: the engine is IAM-restricted — only the mega-care backend SA may invoke
+# it — so an UNAUTHENTICATED probe now returns HTTP 403. A 401/403 therefore means "up + auth
+# working" (healthy); only a connection failure (000) or a 5xx means the service itself is down.
+# We can no longer run an unauthenticated /triage functional probe — liveness (any HTTP response)
+# is the check. (Cloud Run also RESERVES /healthz — GFE 404s it — so probe /viewer/index.html.)
+section "🩸 Nótt HB (prod)"
+NOTT_ENGINE_URL="${NOTT_ENGINE_URL:-https://nott-engine-842423068850.asia-southeast1.run.app}"
+code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$NOTT_ENGINE_URL/viewer/index.html" 2>/dev/null)
+case "$code" in
+  200)     ok "Nótt HB engine reachable (Cloud Run, HTTP 200)" ;;
+  401|403) ok "Nótt HB engine reachable (Cloud Run, HTTP $code — IAM-locked, backend-only)" ;;
+  *)       fail "Nótt HB engine (Cloud Run) unreachable/erroring (HTTP ${code:-000}) — prod Doctor-Consult Hypoxic Burden at risk" ;;
+esac
+# chat + Sleep-Expert agents run on the Mac (local-LLM). Tunnel down = degrade only (HB unaffected).
+NOTT_CHAT_HC="${NOTT_CHAT_HC:-https://nott.megawiz.co.th}"
+if curl -sf --max-time 8 "$NOTT_CHAT_HC/healthz" >/dev/null 2>&1; then
+  ok "Nótt chat/agent engine reachable (Mac tunnel)"
+else
+  warn "Nótt chat engine (Mac tunnel) unreachable — /nott-chat + Sleep-Expert degrade (HB unaffected, on Cloud Run)"
+fi
+
+# ── 6. launchd ops jobs ───────────────────────────────────────────────────
+# 2026-08-21: nightly-backup, ca-expiry-watch and boot-report had been dead for
+# weeks. A job whose script disappears (a branch switch is enough — launchd runs
+# them straight out of the Asgard working tree) exits EX_CONFIG 78, lands in the
+# penalty box and never runs again. Nothing else in this file would notice: the
+# backup-age check only catches it days late, and a CA watch that never runs has
+# no symptom at all until the certificate expires.
+section "🚀 launchd ops jobs"
+LD_BAD=0
+UID_NUM=$(id -u)
+while read -r LABEL; do
+  [[ -z "$LABEL" ]] && continue
+  INFO=$(launchctl print "gui/${UID_NUM}/${LABEL}" 2>/dev/null)
+  if [[ -z "$INFO" ]]; then warn "launchd ${LABEL}: not loaded"; LD_BAD=1; continue; fi
+  # Every absolute path the job executes must exist — covers both the bare
+  # script and the "/bin/bash <script>" form.
+  MISSING=$(echo "$INFO" | awk '/arguments = \{/{a=1;next} a&&/\}/{a=0} a{gsub(/^[ \t]+|[ \t]+$/,"");if($0 ~ /^\//) print}' \
+            | while IFS= read -r P; do [[ -e "$P" ]] || echo "$P"; done)
+  if [[ -n "$MISSING" ]]; then
+    fail "launchd ${LABEL}: program missing ($(echo "$MISSING" | head -1))"; LD_BAD=1; continue
+  fi
+  # A running job's last exit code is history, not a verdict.
+  echo "$INFO" | grep -q "state = running" && continue
+  EC=$(echo "$INFO" | awk -F'= ' '/last exit code/{print $2; exit}')
+  case "$EC" in
+    78*)          fail "launchd ${LABEL}: EX_CONFIG 78 — penalty box, job never runs"; LD_BAD=1 ;;
+    0|"(never exited)"|"") ;;
+    *)            warn "launchd ${LABEL}: last exit ${EC}"; LD_BAD=1 ;;
+  esac
+done < <(launchctl list 2>/dev/null | grep -oE 'com\.asgard\.[a-z0-9.-]+' | sort -u)
+(( LD_BAD == 0 )) && ok "launchd asgard jobs healthy"
+
+# ── verdict ───────────────────────────────────────────────────────────────
+CODE=0; (( ${#WARNS[@]} > 0 )) && CODE=1; (( ${#FAILS[@]} > 0 )) && CODE=2
+if [[ $JSON -eq 1 ]]; then
+  # build JSON arrays — guard empties so an empty array is [] not [""]
+  # (printf with a format + zero args emits one empty field → the [""] bug).
+  fails_json=""; warns_json=""
+  (( ${#FAILS[@]} )) && fails_json=$(printf '"%s",' "${FAILS[@]}" | sed 's/,$//')
+  (( ${#WARNS[@]} )) && warns_json=$(printf '"%s",' "${WARNS[@]}" | sed 's/,$//')
+  printf '{"code":%d,"status":"%s","fail":[%s],"warn":[%s],"ok_count":%d}\n' \
+    "$CODE" "$([[ $CODE -eq 0 ]] && echo OK || ([[ $CODE -eq 1 ]] && echo WARN || echo FAIL))" \
+    "$fails_json" "$warns_json" "${#OKS[@]}"
+else
+  echo -e "\n═══════════════════════"
+  echo -e "Result: ${GREEN}${#OKS[@]} ok${NC}, ${YEL}${#WARNS[@]} warn${NC}, ${RED}${#FAILS[@]} fail${NC}  → exit $CODE"
+fi
+exit $CODE

--- a/scripts/asgard-watchdog.sh
+++ b/scripts/asgard-watchdog.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# asgard-watchdog — runs asgard-preflight on a timer and raises an alert when
+# the cluster/infra degrades. HOST-SIDE on purpose: the 2026-06-12 outage took
+# down the in-cluster observability path (Odin) too, so the watchdog must NOT
+# depend on the cluster it watches. It writes alerts straight to the OpenSearch
+# indexer (which survives cluster outages) and to a local log.
+#
+# Debounced: alerts once on OK→DEGRADED, re-alerts only every REPEAT_EVERY ticks
+# while still degraded, and once on DEGRADED→RECOVERED. No per-tick spam.
+#
+# Meant to be driven by launchd (com.asgard.watchdog) every ~5 min, or run by hand.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PREFLIGHT="${PREFLIGHT:-$HERE/asgard-preflight.sh}"
+STATE="${STATE:-$HOME/.asgard-watchdog.state}"
+LOG="${LOG:-$HOME/.asgard-watchdog.log}"
+
+ALERT_THRESHOLD="${ALERT_THRESHOLD:-2}"   # 2=FAIL only, 1=also WARN
+REPEAT_EVERY="${REPEAT_EVERY:-12}"        # re-alert every N ticks while degraded (~1h at 5min)
+
+# Opt-in auto-recovery (INC-2026-06-15): when a runtime wedge is detected, restart
+# OrbStack (`orbctl stop/start`, the documented fix). OFF by default — restarting
+# the cluster is disruptive; set AUTO_RECOVER=1 to enable. Guards: wedge signal
+# only, at most once per cooldown, alert before + after.
+AUTO_RECOVER="${AUTO_RECOVER:-0}"
+RECOVER_AFTER_TICKS="${RECOVER_AFTER_TICKS:-3}"       # require N consecutive wedge ticks (~15min @5min) before restarting — debounce transient blips
+RECOVER_COOLDOWN="${RECOVER_COOLDOWN:-3600}"          # seconds (max 1 restart/hour)
+RECOVER_STATE="${RECOVER_STATE:-$HOME/.asgard-watchdog.recover}"
+ORBCTL="${ORBCTL:-$(command -v orbctl 2>/dev/null || echo /usr/local/bin/orbctl)}"
+
+INDEXER_URL="${INDEXER_URL:-https://localhost:30920}"
+INDEXER_USER="${INDEXER_USER:-admin}"
+INDEXER_PASS="${INDEXER_PASS:-admin}"
+INDEX="${INDEX:-asgard-alerts}"
+
+# Secrets/overrides (e.g. DISCORD_WEBHOOK) live in a gitignored, chmod-600 file —
+# NOT committed. launchd has no shell env, so we source it explicitly.
+[[ -f "$HOME/.asgard-watchdog.env" ]] && source "$HOME/.asgard-watchdog.env"
+DISCORD_WEBHOOK="${DISCORD_WEBHOOK:-}"
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+HOST=$(scutil --get LocalHostName 2>/dev/null || hostname)
+
+# run preflight (read-only)
+JSON=$("$PREFLIGHT" --json 2>/dev/null); CODE=$?
+
+# previous state
+PREV_CODE=0; SINCE=0
+if [[ -f "$STATE" ]]; then read -r PREV_CODE SINCE < "$STATE" 2>/dev/null || true; fi
+[[ "$PREV_CODE" =~ ^[0-9]+$ ]] || PREV_CODE=0
+[[ "$SINCE" =~ ^[0-9]+$ ]] || SINCE=0
+
+degraded() { (( $1 >= ALERT_THRESHOLD )); }
+
+ACTION="none"
+if degraded "$CODE"; then
+  if ! degraded "$PREV_CODE"; then ACTION="degraded"; SINCE=1
+  else SINCE=$((SINCE+1)); (( SINCE % REPEAT_EVERY == 0 )) && ACTION="reminder"; fi
+else
+  if degraded "$PREV_CODE"; then ACTION="recovered"; fi
+  SINCE=0
+fi
+
+printf '%s %s\n' "$CODE" "$SINCE" > "$STATE"
+printf '%s code=%s action=%s %s\n' "$NOW" "$CODE" "$ACTION" "$JSON" >> "$LOG"
+
+# Heartbeat: every tick, publish the CURRENT health snapshot (id=current) so Odin /
+# agents can read live status (not just transition alerts). Best-effort.
+HEARTBEAT=$(JSON="$JSON" NOW="$NOW" HOST="$HOST" CODE="$CODE" python3 -c '
+import json,os
+pf=json.loads(os.environ["JSON"])
+print(json.dumps({"@timestamp":os.environ["NOW"],"ts":os.environ["NOW"],"source":"asgard-watchdog","kind":"heartbeat","host":os.environ["HOST"],"code":int(os.environ["CODE"]),"status":pf.get("status"),"fail":pf.get("fail",[]),"warn":pf.get("warn",[]),"fail_count":len(pf.get("fail",[]))}))' 2>/dev/null)
+[ -n "$HEARTBEAT" ] && curl -sk --max-time 10 -u "$INDEXER_USER:$INDEXER_PASS" \
+  -X PUT "$INDEXER_URL/$INDEX/_doc/current" \
+  -H 'Content-Type: application/json' --data-binary "$HEARTBEAT" >/dev/null 2>&1
+
+send_alert() {
+  local kind="$1"
+  local doc
+  doc=$(JSON="$JSON" NOW="$NOW" HOST="$HOST" KIND="$kind" CODE="$CODE" python3 -c '
+import json,os
+pf=json.loads(os.environ["JSON"])
+print(json.dumps({
+  "@timestamp": os.environ["NOW"],
+  "source": "asgard-watchdog",
+  "host": os.environ["HOST"],
+  "kind": os.environ["KIND"],
+  "code": int(os.environ["CODE"]),
+  "status": pf.get("status"),
+  "fail": pf.get("fail", []),
+  "warn": pf.get("warn", []),
+  "fail_count": len(pf.get("fail", [])),
+}))') || return 1
+  curl -sk --max-time 12 -u "$INDEXER_USER:$INDEXER_PASS" \
+    -X POST "$INDEXER_URL/$INDEX/_doc?refresh=wait_for" \
+    -H 'Content-Type: application/json' --data-binary "$doc" >/dev/null 2>&1 \
+    && echo "[watchdog] alert sent ($kind) → $INDEX" \
+    || echo "[watchdog] WARN: could not reach indexer to send $kind alert"
+
+  send_discord "$kind"
+}
+
+# Post a human-readable embed to Discord (only if a webhook is configured).
+send_discord() {
+  [[ -z "$DISCORD_WEBHOOK" ]] && return 0
+  local kind="$1"
+  local payload
+  payload=$(JSON="$JSON" HOST="$HOST" KIND="$kind" NOW="$NOW" python3 -c '
+import json,os
+pf=json.loads(os.environ["JSON"]); kind=os.environ["KIND"]
+color={"degraded":15158332,"reminder":15105570,"recovered":3066993}.get(kind,9807270)  # red/orange/green
+emoji={"degraded":"🔴","reminder":"🟠","recovered":"🟢"}.get(kind,"⚪")
+title={"degraded":"Asgard DEGRADED","reminder":"Asgard still degraded","recovered":"Asgard RECOVERED"}.get(kind,"Asgard")
+fails=pf.get("fail",[]) or pf.get("warn",[])
+# Discord embed: cap field length to stay under limits
+desc="\n".join("• "+f for f in fails[:12]) or "all checks passing"
+if len(fails)>12: desc+=f"\n…and {len(fails)-12} more"
+print(json.dumps({"embeds":[{
+  "title":f"{emoji} {title}",
+  "description":desc[:3900],
+  "color":color,
+  "fields":[{"name":"status","value":str(pf.get("status")),"inline":True},
+            {"name":"failing","value":str(len(pf.get("fail",[]))),"inline":True},
+            {"name":"host","value":os.environ["HOST"],"inline":True}],
+  "footer":{"text":"asgard-watchdog • "+os.environ["NOW"]}
+}]}))') || return 0
+  curl -s --max-time 12 -H 'Content-Type: application/json' \
+    -d "$payload" "$DISCORD_WEBHOOK" >/dev/null 2>&1 \
+    && echo "[watchdog] Discord notified ($kind)" \
+    || echo "[watchdog] WARN: Discord webhook post failed"
+}
+
+# Opt-in: restart OrbStack on a sustained runtime wedge (INC-2026-06-15). Only
+# fires on the wedge signal, after ≥RECOVER_AFTER_TICKS consecutive degraded
+# ticks (debounce), at most once per cooldown, alerts before + after. No-op
+# unless AUTO_RECOVER=1, so it can't surprise-restart the cluster.
+maybe_auto_recover() {
+  [[ "$AUTO_RECOVER" == "1" ]] || return 0
+  degraded "$CODE" || return 0
+  printf '%s' "$JSON" | grep -qiE 'cluster unreachable|Terminating >1h|sandbox|PLEG|OrbStack' || return 0
+  # debounce: only on a SUSTAINED wedge, not a one-off blip. SINCE is the
+  # consecutive-degraded counter from the state machine above.
+  if (( SINCE < RECOVER_AFTER_TICKS )); then
+    echo "[watchdog] auto-recover armed (wedge ${SINCE}/${RECOVER_AFTER_TICKS} ticks — holding)"; return 0
+  fi
+  local last=0 now; [[ -f "$RECOVER_STATE" ]] && last=$(cat "$RECOVER_STATE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  if (( now - last < RECOVER_COOLDOWN )); then
+    echo "[watchdog] auto-recover suppressed (cooldown — last $(( now - last ))s ago)"; return 0
+  fi
+  echo "$now" > "$RECOVER_STATE"
+  echo "[watchdog] 🛠️ AUTO-RECOVER: runtime wedge → $ORBCTL stop/start"
+  [[ -n "$DISCORD_WEBHOOK" ]] && curl -s --max-time 10 -H 'Content-Type: application/json' \
+    -d '{"content":"🛠️ asgard-watchdog AUTO-RECOVER: runtime wedge — restarting OrbStack (orbctl stop/start)"}' \
+    "$DISCORD_WEBHOOK" >/dev/null 2>&1
+  "$ORBCTL" stop >/dev/null 2>&1; sleep 3; "$ORBCTL" start >/dev/null 2>&1
+  [[ -n "$DISCORD_WEBHOOK" ]] && curl -s --max-time 10 -H 'Content-Type: application/json' \
+    -d '{"content":"✅ asgard-watchdog: OrbStack restarted — pods rescheduling"}' \
+    "$DISCORD_WEBHOOK" >/dev/null 2>&1
+}
+
+case "$ACTION" in
+  degraded)  echo "[watchdog] OK→DEGRADED (code=$CODE)"; send_alert "degraded" ;;
+  reminder)  echo "[watchdog] still degraded (${SINCE} ticks)"; send_alert "reminder" ;;
+  recovered) echo "[watchdog] DEGRADED→RECOVERED"; send_alert "recovered" ;;
+  none)      echo "[watchdog] code=$CODE, no state change" ;;
+esac
+
+# Evaluated EVERY tick (not only on alert transitions) so the ≥N-tick debounce
+# can fire mid-streak; its own guards decide whether it actually restarts.
+maybe_auto_recover
+
+exit 0

--- a/scripts/backup-full-k8s.sh
+++ b/scripts/backup-full-k8s.sh
@@ -91,7 +91,13 @@ backup_neo4j() {
   local orig; orig=$(kubectl get deploy "$deploy" -n "$ns" -o jsonpath='{.spec.replicas}' 2>/dev/null); orig="${orig:-1}"
   kubectl scale deploy/"$deploy" -n "$ns" --replicas=0 >/dev/null 2>&1
   for i in $(seq 1 24); do kubectl get pods -n "$ns" --no-headers 2>/dev/null | grep -q "^${deploy}-" || break; sleep 5; done
-  kubectl apply -f - >/dev/null 2>&1 <<YAML
+  # 2026-08-21: this whole step failed in about one second and recorded only
+  # "neo4j | FAIL | copyout" — every command was silenced, so the real error was
+  # gone. Surface the errors, and pre-delete a stale helper (a pod left over from
+  # an interrupted run makes `apply` fail outright, since pod specs are immutable).
+  kubectl delete pod neo4j-backup-helper -n "$ns" --ignore-not-found --timeout=90s >/dev/null 2>&1
+  local apply_err
+  apply_err=$(kubectl apply -f - 2>&1 <<YAML
 apiVersion: v1
 kind: Pod
 metadata: {name: neo4j-backup-helper, namespace: ${ns}}
@@ -102,9 +108,13 @@ spec:
   volumes:
   - {name: data, persistentVolumeClaim: {claimName: ${pvc}}}
 YAML
-  kubectl wait --for=condition=Ready pod/neo4j-backup-helper -n "$ns" --timeout=120s >/dev/null 2>&1
-  kubectl exec -n "$ns" neo4j-backup-helper -- neo4j-admin database dump neo4j --to-path=/tmp --overwrite-destination >/dev/null 2>&1 \
-    && OK "  dump complete" || ERR "  dump failed"
+) || ERR "  helper pod apply failed: ${apply_err}"
+  if ! kubectl wait --for=condition=Ready pod/neo4j-backup-helper -n "$ns" --timeout=120s >/dev/null 2>&1; then
+    ERR "  helper pod not Ready: $(kubectl get pod neo4j-backup-helper -n "$ns" --no-headers 2>&1 | tail -1)"
+  fi
+  local dump_out
+  dump_out=$(kubectl exec -n "$ns" neo4j-backup-helper -- neo4j-admin database dump neo4j --to-path=/tmp --overwrite-destination 2>&1) \
+    && OK "  dump complete" || ERR "  dump failed: $(echo "$dump_out" | grep -iE 'error|failed' | tail -1)"
   if kubectl exec -n "$ns" neo4j-backup-helper -- cat /tmp/neo4j.dump > "${DEST}/01-databases/neo4j.dump" 2>/dev/null && [ -s "${DEST}/01-databases/neo4j.dump" ]; then
     local sz; sz=$(du -h "${DEST}/01-databases/neo4j.dump" | cut -f1); OK "Neo4j → neo4j.dump ($sz)"; record "neo4j" OK "$sz"
   else ERR "Neo4j copy-out failed"; record "neo4j" FAIL "copyout"; fi

--- a/scripts/backup-full-k8s.sh
+++ b/scripts/backup-full-k8s.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  🏰 ASGARD — Full Backup (K8s-aware) → T7 external            ║
+# ║  All databases + PVs, for rollback / disaster recovery        ║
+# ╚══════════════════════════════════════════════════════════════╝
+#
+# Replaces the docker-compose-era scripts/backup.sh (which used
+# `docker exec asgard_neo4j` container names that don't exist in the
+# current OrbStack K8s deployment). Discovers pods dynamically.
+#
+# Usage:
+#   ./scripts/backup-full-k8s.sh                 # full backup to T7
+#   DEST=/some/path ./scripts/backup-full-k8s.sh # custom dest
+#
+# Strategy:
+#   - SQL stores  → logical dumps (online-safe, rollback-grade)
+#   - Neo4j       → STOP DATABASE → neo4j-admin dump → START (brief offline)
+#   - Qdrant      → snapshot API via port-forward
+#   - ClickHouse  → raw data tar (observability data, best-effort)
+#   - RabbitMQ    → definitions.json
+#   - Other PVs   → raw tar via `kubectl exec tar` (best-effort, skipped if no tar)
+#   - Vault       → raft snapshot if available, else PVC tar (unseal keys NOT included)
+#   - K8s         → PVC/PV definitions + per-namespace manifests
+#
+# Every step is fault-tolerant: failures are logged, never abort the run.
+set -uo pipefail
+
+TS=$(date +%Y-%m-%d_%H%M%S)
+DATE=$(date +%Y-%m-%d)
+DEST="${DEST:-/Volumes/T7 Shield/asgard-backup-${DATE}}"
+LOG() { echo "$(date +%H:%M:%S) [BACKUP] $*"; }
+OK()  { echo "$(date +%H:%M:%S) [  ✅  ] $*"; }
+ERR() { echo "$(date +%H:%M:%S) [  ❌  ] $*" >&2; }
+SKIP(){ echo "$(date +%H:%M:%S) [  ⏭️  ] $*"; }
+
+declare -a RESULTS=()
+record() { RESULTS+=("$1|$2|$3"); }   # name|status|detail
+
+mkdir -p "$DEST"/{01-databases,02-snapshots,03-pv-raw,04-k8s,05-vault}
+LOG "=== Asgard Full Backup ${TS} ==="
+LOG "Destination: ${DEST}"
+echo
+
+# Resolve current pod name by namespace + label-ish name prefix
+pod_for() {  # $1=ns $2=name-prefix
+  kubectl get pods -n "$1" --no-headers 2>/dev/null \
+    | awk -v p="$2" '$1 ~ "^"p && $3=="Running" {print $1; exit}'
+}
+
+# ── 1. MariaDB (logical) ──
+backup_mariadb() {  # $1=ns $2=podprefix $3=outfile
+  local ns="$1" pod; pod=$(pod_for "$ns" "$2")
+  [ -z "$pod" ] && { SKIP "MariaDB ${ns}/$2 — no running pod"; record "mariadb-${ns}" SKIP "no pod"; return; }
+  LOG "📊 MariaDB ${ns}/${pod} → $3"
+  # NOTE: mariadb:11 image ships `mariadb-dump`, not `mysqldump` (no symlink)
+  if kubectl exec -n "$ns" "$pod" -- sh -c \
+      'mariadb-dump --all-databases --single-transaction --routines --triggers --events \
+       -uroot -p"${MYSQL_ROOT_PASSWORD:-${MARIADB_ROOT_PASSWORD:-root}}" 2>/dev/null' \
+      | gzip > "${DEST}/01-databases/$3"; then
+    local sz; sz=$(du -h "${DEST}/01-databases/$3" | cut -f1)
+    [ -s "${DEST}/01-databases/$3" ] && { OK "MariaDB ${ns} → $3 ($sz)"; record "mariadb-${ns}" OK "$sz"; } \
+      || { ERR "MariaDB ${ns} dump empty"; record "mariadb-${ns}" FAIL "empty"; }
+  else ERR "MariaDB ${ns} dump failed"; record "mariadb-${ns}" FAIL "exec error"; fi
+}
+
+# ── 2. PostgreSQL (logical) ──
+backup_postgres() {  # $1=ns $2=podprefix $3=outfile
+  local ns="$1" pod; pod=$(pod_for "$ns" "$2")
+  [ -z "$pod" ] && { SKIP "Postgres ${ns}/$2 — no running pod"; record "postgres-${ns}-$2" SKIP "no pod"; return; }
+  LOG "🐘 Postgres ${ns}/${pod} → $3"
+  if kubectl exec -n "$ns" "$pod" -- sh -c \
+      'PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD:-}}" pg_dumpall -U "${POSTGRES_USER:-postgres}" 2>/dev/null' \
+      | gzip > "${DEST}/01-databases/$3"; then
+    local sz; sz=$(du -h "${DEST}/01-databases/$3" | cut -f1)
+    [ -s "${DEST}/01-databases/$3" ] && { OK "Postgres → $3 ($sz)"; record "postgres-$2" OK "$sz"; } \
+      || { ERR "Postgres $2 dump empty"; record "postgres-$2" FAIL "empty"; }
+  else ERR "Postgres $2 dump failed"; record "postgres-$2" FAIL "exec error"; fi
+}
+
+# ── 3. Neo4j (binary dump) ──
+# Community edition: STOP/START DATABASE is Enterprise-only, so the whole DBMS
+# must be offline. We scale the deployment to 0, dump via a helper pod that
+# mounts the same (RWO) PVC, then scale back. Brief Neo4j downtime (~1-2 min).
+backup_neo4j() {
+  local ns="asgard-infra" deploy="neo4j"
+  local img; img=$(kubectl get deploy "$deploy" -n "$ns" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  local pvc; pvc=$(kubectl get deploy "$deploy" -n "$ns" -o jsonpath='{.spec.template.spec.volumes[?(@.persistentVolumeClaim)].persistentVolumeClaim.claimName}' 2>/dev/null | awk '{print $1}')
+  [ -z "$img" ] && { SKIP "Neo4j — deploy not found"; record "neo4j" SKIP "no deploy"; return; }
+  pvc="${pvc:-neo4j-data}"
+  LOG "🕸️  Neo4j — scale 0 → helper dump → scale 1 (img=$img pvc=$pvc)"
+  local orig; orig=$(kubectl get deploy "$deploy" -n "$ns" -o jsonpath='{.spec.replicas}' 2>/dev/null); orig="${orig:-1}"
+  kubectl scale deploy/"$deploy" -n "$ns" --replicas=0 >/dev/null 2>&1
+  for i in $(seq 1 24); do kubectl get pods -n "$ns" --no-headers 2>/dev/null | grep -q "^${deploy}-" || break; sleep 5; done
+  kubectl apply -f - >/dev/null 2>&1 <<YAML
+apiVersion: v1
+kind: Pod
+metadata: {name: neo4j-backup-helper, namespace: ${ns}}
+spec:
+  restartPolicy: Never
+  containers:
+  - {name: dump, image: ${img}, command: ["sleep","900"], volumeMounts: [{name: data, mountPath: /data}]}
+  volumes:
+  - {name: data, persistentVolumeClaim: {claimName: ${pvc}}}
+YAML
+  kubectl wait --for=condition=Ready pod/neo4j-backup-helper -n "$ns" --timeout=120s >/dev/null 2>&1
+  kubectl exec -n "$ns" neo4j-backup-helper -- neo4j-admin database dump neo4j --to-path=/tmp --overwrite-destination >/dev/null 2>&1 \
+    && OK "  dump complete" || ERR "  dump failed"
+  if kubectl exec -n "$ns" neo4j-backup-helper -- cat /tmp/neo4j.dump > "${DEST}/01-databases/neo4j.dump" 2>/dev/null && [ -s "${DEST}/01-databases/neo4j.dump" ]; then
+    local sz; sz=$(du -h "${DEST}/01-databases/neo4j.dump" | cut -f1); OK "Neo4j → neo4j.dump ($sz)"; record "neo4j" OK "$sz"
+  else ERR "Neo4j copy-out failed"; record "neo4j" FAIL "copyout"; fi
+  kubectl delete pod neo4j-backup-helper -n "$ns" --wait=false >/dev/null 2>&1
+  kubectl scale deploy/"$deploy" -n "$ns" --replicas="$orig" >/dev/null 2>&1   # ALWAYS restore service
+  for i in $(seq 1 36); do kubectl get pods -n "$ns" --no-headers 2>/dev/null | grep "^${deploy}-" | grep -q "1/1 .*Running" && { OK "  neo4j back online"; break; }; sleep 5; done
+}
+
+# ── 4. Qdrant (snapshot API via port-forward) ──
+backup_qdrant() {  # $1=ns $2=podprefix $3=subdir $4=localport
+  local ns="$1" pod; pod=$(pod_for "$ns" "$2")
+  [ -z "$pod" ] && { SKIP "Qdrant ${ns} — no pod"; record "qdrant-${ns}" SKIP "no pod"; return; }
+  local lp="$4"
+  LOG "🔍 Qdrant ${ns}/${pod} (pf :$lp)"
+  kubectl port-forward -n "$ns" "pod/$pod" "${lp}:6333" >/dev/null 2>&1 &
+  local pf=$!; sleep 4
+  local cols; cols=$(curl -sf "http://localhost:${lp}/collections" 2>/dev/null \
+    | python3 -c "import sys,json;[print(c['name']) for c in json.load(sys.stdin)['result']['collections']]" 2>/dev/null)
+  if [ -z "$cols" ]; then SKIP "Qdrant ${ns} — no collections / unreachable"; record "qdrant-${ns}" SKIP "no collections"; kill $pf 2>/dev/null; return; fi
+  mkdir -p "${DEST}/02-snapshots/$3"
+  local n=0
+  for c in $cols; do
+    local snap; snap=$(curl -sf -X POST "http://localhost:${lp}/collections/${c}/snapshots" 2>/dev/null \
+      | python3 -c "import sys,json;print(json.load(sys.stdin)['result']['name'])" 2>/dev/null)
+    [ -z "$snap" ] && { ERR "  ${c}: snapshot create failed"; continue; }
+    if curl -sf "http://localhost:${lp}/collections/${c}/snapshots/${snap}" -o "${DEST}/02-snapshots/$3/${c}.snapshot" 2>/dev/null; then
+      OK "  ${c} → ${c}.snapshot"; n=$((n+1))
+      # Qdrant keeps the snapshot on the pod's own disk after we pull it, and
+      # nothing else ever removes it. Left alone this leaks ~2.2 GB/night into
+      # the Qdrant PVC (found 2026-07-20 at 11.8 GB, disk 81% full) — the same
+      # disk whose pressure evicts pods. Delete only after the download
+      # succeeded: if the pull failed we keep the server-side copy so the
+      # snapshot is still recoverable by hand.
+      curl -sf -X DELETE "http://localhost:${lp}/collections/${c}/snapshots/${snap}" >/dev/null 2>&1 \
+        || ERR "  ${c}: server-side snapshot cleanup failed (${snap})"
+    else ERR "  ${c}: download failed"; fi
+  done
+  kill $pf 2>/dev/null
+  record "qdrant-${ns}" OK "${n} collections"
+}
+
+# ── 5. ClickHouse (raw tar) + RabbitMQ (definitions) ──
+backup_clickhouse() {
+  local ns="asgard" pod; pod=$(pod_for "$ns" "laminar-clickhouse")
+  [ -z "$pod" ] && { SKIP "ClickHouse — no pod"; record "clickhouse" SKIP "no pod"; return; }
+  LOG "📈 ClickHouse ${pod} (raw tar)"
+  if kubectl exec -n "$ns" "$pod" -- tar czf - -C /var/lib/clickhouse . 2>/dev/null > "${DEST}/01-databases/clickhouse-data.tar.gz" && [ -s "${DEST}/01-databases/clickhouse-data.tar.gz" ]; then
+    local sz; sz=$(du -h "${DEST}/01-databases/clickhouse-data.tar.gz" | cut -f1)
+    OK "ClickHouse → clickhouse-data.tar.gz ($sz)"; record "clickhouse" OK "$sz"
+  else ERR "ClickHouse tar failed"; record "clickhouse" FAIL "tar error"; fi
+}
+backup_rabbitmq() {
+  local ns="asgard" pod; pod=$(pod_for "$ns" "laminar-rabbitmq")
+  [ -z "$pod" ] && { SKIP "RabbitMQ — no pod"; record "rabbitmq" SKIP "no pod"; return; }
+  LOG "🐰 RabbitMQ ${pod} (definitions)"
+  if kubectl exec -n "$ns" "$pod" -- rabbitmqctl export_definitions /tmp/defs.json 2>/dev/null \
+     && kubectl exec -n "$ns" "$pod" -- cat /tmp/defs.json > "${DEST}/01-databases/rabbitmq-definitions.json" 2>/dev/null \
+     && [ -s "${DEST}/01-databases/rabbitmq-definitions.json" ]; then
+    OK "RabbitMQ → rabbitmq-definitions.json"; record "rabbitmq" OK "defs"
+  else ERR "RabbitMQ export failed"; record "rabbitmq" FAIL "export error"; fi
+}
+
+# ── 6. Generic raw PV tar (find pod+mountPath for a PVC) ──
+backup_pv_raw() {  # $1=ns $2=pvc $3=outname
+  local ns="$1" pvc="$2"
+  read -r pod mp < <(kubectl get pods -n "$ns" -o json 2>/dev/null | python3 -c "
+import sys,json
+ns_pvc='$pvc'
+data=json.load(sys.stdin)
+for p in data['items']:
+    if p.get('status',{}).get('phase')!='Running': continue
+    vols={v['name']:v for v in p['spec'].get('volumes',[])}
+    claim={n:v for n,v in vols.items() if v.get('persistentVolumeClaim',{}).get('claimName')==ns_pvc}
+    if not claim: continue
+    for c in p['spec']['containers']:
+        for m in c.get('volumeMounts',[]):
+            if m['name'] in claim:
+                print(p['metadata']['name'], m['mountPath']); sys.exit()
+" 2>/dev/null)
+  [ -z "${pod:-}" ] && { SKIP "PV ${pvc} — no mounting pod"; record "pv-${pvc}" SKIP "no pod"; return; }
+  LOG "💾 PV ${pvc} from ${pod}:${mp} → $3"
+  if kubectl exec -n "$ns" "$pod" -- tar czf - -C "$mp" . 2>/dev/null > "${DEST}/03-pv-raw/$3" && [ -s "${DEST}/03-pv-raw/$3" ]; then
+    local sz; sz=$(du -h "${DEST}/03-pv-raw/$3" | cut -f1)
+    OK "PV ${pvc} → $3 ($sz)"; record "pv-${pvc}" OK "$sz"
+  else ERR "PV ${pvc} tar failed (no tar in image?)"; record "pv-${pvc}" FAIL "tar error"; fi
+}
+
+# ── 6b. MinIO (distroless image has no `tar`) ──
+# Same pattern as Neo4j: scale deploy to 0, mount the RWO PVC in a busybox helper
+# (which HAS tar+gzip), stream out, scale back. Brief MinIO downtime (~30-60s).
+backup_minio() {
+  local ns="asgard-infra" deploy="minio" pvc="minio-pvc" out="minio.tar.gz"
+  kubectl get deploy "$deploy" -n "$ns" >/dev/null 2>&1 || { SKIP "MinIO — deploy not found"; record "pv-minio-pvc" SKIP "no deploy"; return; }
+  pvc=$(kubectl get deploy "$deploy" -n "$ns" -o jsonpath='{.spec.template.spec.volumes[?(@.persistentVolumeClaim)].persistentVolumeClaim.claimName}' 2>/dev/null | awk '{print $1}'); pvc="${pvc:-minio-pvc}"
+  LOG "💾 MinIO — scale 0 → busybox helper tar → scale 1 (pvc=$pvc)"
+  local orig; orig=$(kubectl get deploy "$deploy" -n "$ns" -o jsonpath='{.spec.replicas}' 2>/dev/null); orig="${orig:-1}"
+  kubectl scale deploy/"$deploy" -n "$ns" --replicas=0 >/dev/null 2>&1
+  for i in $(seq 1 24); do kubectl get pods -n "$ns" --no-headers 2>/dev/null | grep -q "^${deploy}-" || break; sleep 5; done
+  kubectl apply -f - >/dev/null 2>&1 <<YAML
+apiVersion: v1
+kind: Pod
+metadata: {name: minio-backup-helper, namespace: ${ns}}
+spec:
+  restartPolicy: Never
+  containers:
+  - {name: tar, image: busybox:1.36, command: ["sleep","900"], volumeMounts: [{name: data, mountPath: /data}]}
+  volumes:
+  - {name: data, persistentVolumeClaim: {claimName: ${pvc}}}
+YAML
+  kubectl wait --for=condition=Ready pod/minio-backup-helper -n "$ns" --timeout=120s >/dev/null 2>&1
+  if kubectl exec -n "$ns" minio-backup-helper -- sh -c 'tar cf - -C /data . | gzip' 2>/dev/null > "${DEST}/03-pv-raw/$out" && [ -s "${DEST}/03-pv-raw/$out" ]; then
+    local sz; sz=$(du -h "${DEST}/03-pv-raw/$out" | cut -f1); OK "MinIO → $out ($sz)"; record "pv-minio-pvc" OK "$sz"
+  else ERR "MinIO helper tar failed"; record "pv-minio-pvc" FAIL "helper tar"; fi
+  kubectl delete pod minio-backup-helper -n "$ns" --wait=false >/dev/null 2>&1
+  kubectl scale deploy/"$deploy" -n "$ns" --replicas="$orig" >/dev/null 2>&1   # ALWAYS restore service
+  for i in $(seq 1 36); do kubectl get pods -n "$ns" --no-headers 2>/dev/null | grep "^${deploy}-" | grep -q "1/1 .*Running" && { OK "  minio back online"; break; }; sleep 5; done
+}
+
+# ── 7. Vault (raft snapshot, no unseal keys) ──
+backup_vault() {
+  local ns="asgard" pod; pod=$(pod_for "$ns" "fafnir-vault")
+  [ -z "$pod" ] && { SKIP "Vault — no pod"; record "vault" SKIP "no pod"; return; }
+  LOG "🔐 Vault ${pod} — raft snapshot (unseal keys NOT included — manual)"
+  if kubectl exec -n "$ns" "$pod" -- sh -c 'vault operator raft snapshot save /tmp/vault.snap 2>/dev/null' \
+     && kubectl exec -n "$ns" "$pod" -- cat /tmp/vault.snap > "${DEST}/05-vault/vault-raft.snap" 2>/dev/null \
+     && [ -s "${DEST}/05-vault/vault-raft.snap" ]; then
+    OK "Vault → vault-raft.snap"; record "vault" OK "raft snapshot"
+    kubectl exec -n "$ns" "$pod" -- rm -f /tmp/vault.snap 2>/dev/null
+  else
+    SKIP "Vault raft snapshot unavailable (sealed/not-raft) — see 05-vault/MANUAL.md"
+    record "vault" MANUAL "raft unavailable"
+  fi
+  cat > "${DEST}/05-vault/MANUAL.md" <<EOF
+# Vault backup — manual step required
+Unseal keys / root token are NOT in this backup (sensitive).
+To complete rollback capability, securely store init-keys.json out-of-band.
+If raft snapshot present: \`vault operator raft snapshot restore vault-raft.snap\`
+EOF
+}
+
+# ── 8. K8s manifests + PVC/PV definitions ──
+backup_k8s() {
+  LOG "☸️  K8s definitions"
+  kubectl get pvc,pv -A -o yaml > "${DEST}/04-k8s/pvc-pv-definitions.yaml" 2>/dev/null && OK "  PVC/PV definitions"
+  for ns in asgard asgard-infra asgard-monitoring wazuh; do
+    kubectl get all,configmap,secret,ingress -n "$ns" -o yaml > "${DEST}/04-k8s/manifests-${ns}.yaml" 2>/dev/null \
+      && OK "  ns/${ns} manifests" || SKIP "  ns/${ns} (none)"
+  done
+  helm list -A -o yaml > "${DEST}/04-k8s/helm-releases.yaml" 2>/dev/null && OK "  helm releases"
+  record "k8s-manifests" OK "definitions"
+}
+
+# ════════════ RUN ════════════
+backup_mariadb  asgard       "mariadb-67c"        "mariadb-asgard.sql.gz"
+backup_mariadb  asgard-infra "mariadb-585"        "mariadb-infra.sql.gz"
+backup_postgres asgard       "postgres-64"        "postgres-asgard.sql.gz"
+backup_postgres asgard-infra "postgres-66"        "postgres-infra.sql.gz"
+backup_postgres asgard       "laminar-postgres"   "postgres-laminar.sql.gz"
+backup_neo4j
+backup_qdrant   asgard       "qdrant-cf"   "qdrant-asgard" 16333
+backup_qdrant   asgard-infra "qdrant-5f"   "qdrant-infra"  16334
+backup_clickhouse
+backup_rabbitmq
+backup_pv_raw   asgard       "laminar-quickwit-data" "quickwit.tar.gz"
+backup_minio
+backup_pv_raw   asgard       "bifrost-data-pvc"      "bifrost-data.tar.gz"
+backup_pv_raw   asgard       "eir-sites-data"        "eir-sites.tar.gz"
+backup_pv_raw   asgard       "forseti-data"          "forseti-data.tar.gz"
+backup_pv_raw   asgard       "mjolnir-data"          "mjolnir-data.tar.gz"
+backup_pv_raw   asgard       "mimir-medical-docs"    "mimir-medical-docs.tar.gz"
+backup_pv_raw   asgard       "askr-data"             "askr-data.tar.gz"      # Askr faculty studio (exams·catalog·OSCE analytics)
+backup_vault
+backup_k8s
+
+# ── MANIFEST ──
+{
+  echo "# Asgard Full Backup Manifest — ${TS}"
+  echo
+  echo "Destination: \`${DEST}\`"
+  echo "Host: $(hostname)  |  Created: $(date)"
+  echo
+  echo "## Results"
+  echo "| Component | Status | Detail |"
+  echo "|-----------|--------|--------|"
+  for r in "${RESULTS[@]}"; do IFS='|' read -r n s d <<< "$r"; echo "| $n | $s | $d |"; done
+  echo
+  echo "## NOT included (by design)"
+  echo "- Source code repos (~/Developer, 150G) — separate concern"
+  echo "- tyr-* PVs (wazuh SIEM, ~70G) — already on T7 by design (Tyr PVC-on-T7)"
+  echo "- asgard-infra/mariadb-data PVC is Terminating (mid-migration) — logical dump captured instead"
+  echo "- Vault unseal keys / root token — must be stored out-of-band (see 05-vault/MANUAL.md)"
+  echo
+  echo "## Restore order (disaster recovery)"
+  echo "1. Recreate K8s cluster + apply 04-k8s manifests + PVC/PV definitions"
+  echo "2. MariaDB: \`gunzip -c X.sql.gz | mysql\`  (per namespace)"
+  echo "3. Postgres: \`gunzip -c X.sql.gz | psql -U postgres\`"
+  echo "4. Neo4j: STOP DATABASE neo4j; neo4j-admin database load neo4j --from-path=. --overwrite-destination; START DATABASE neo4j"
+  echo "5. Qdrant: snapshot recovery API per collection (02-snapshots/)"
+  echo "6. ClickHouse/Quickwit/others: extract raw tars into fresh PVCs"
+  echo "7. Vault: raft snapshot restore + unseal with out-of-band keys"
+} > "${DEST}/MANIFEST.md"
+
+echo
+LOG "=== Backup complete → ${DEST} ==="
+ls -lhR "${DEST}" 2>/dev/null | grep -vE "^total|^d" | grep -E "\.(gz|dump|snap|json|yaml|md)" | awk '{print $5, $9}'
+echo
+LOG "=== Summary ==="
+for r in "${RESULTS[@]}"; do IFS='|' read -r n s d <<< "$r"; printf "  %-22s %-7s %s\n" "$n" "$s" "$d"; done

--- a/scripts/backup-full-k8s.sh
+++ b/scripts/backup-full-k8s.sh
@@ -36,6 +36,21 @@ SKIP(){ echo "$(date +%H:%M:%S) [  ⏭️  ] $*"; }
 declare -a RESULTS=()
 record() { RESULTS+=("$1|$2|$3"); }   # name|status|detail
 
+# One run at a time. Two of these fight over the same helper pods and scale the
+# same deployments up and down underneath each other: on 2026-08-21 a manual run
+# overlapped the launchd run and the Neo4j dump died between them (the other run
+# owned neo4j-backup-helper, and deleted it mid-flight).
+LOCK="/tmp/asgard-backup-full-k8s.lock"
+if ! mkdir "$LOCK" 2>/dev/null; then
+  if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +180 2>/dev/null)" ]; then
+    LOG "stale lock older than 3h — taking it over ($LOCK)"
+  else
+    ERR "another backup-full-k8s.sh is already running ($LOCK) — refusing to run twice"
+    exit 3
+  fi
+fi
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+
 mkdir -p "$DEST"/{01-databases,02-snapshots,03-pv-raw,04-k8s,05-vault}
 LOG "=== Asgard Full Backup ${TS} ==="
 LOG "Destination: ${DEST}"

--- a/scripts/backup-neo4j-only.sh
+++ b/scripts/backup-neo4j-only.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  🕸️  ASGARD — Neo4j-only backup (cheaper than full)           ║
+# ║  Extracted from backup-full-k8s.sh for Sprint 56 schema       ║
+# ║  migrations that only touch the graph layer.                  ║
+# ╚══════════════════════════════════════════════════════════════╝
+#
+# Use cases (per Sprint 56 plan):
+#   - Pre-flight before Neo4j schema/label changes (POLE+O)
+#   - Pre-flight before bulk :TOUCHED edge materialization
+#   - Pre-flight before consolidation `Apply` mode
+#
+# What it does:
+#   1. scale deploy/neo4j → 0 (Community edition needs whole DBMS offline)
+#   2. launch helper pod mounting the neo4j-data PVC
+#   3. neo4j-admin database dump → copy out → save to DEST
+#   4. ALWAYS scale back to original replica count (trap on EXIT)
+#
+# Downtime: ~1.5 min. Caller is responsible for maintenance window.
+#
+# Usage:
+#   ./scripts/backup-neo4j-only.sh                     # default DEST + tag
+#   DEST=/tmp/neo4j-backup ./scripts/backup-neo4j-only.sh
+#   TAG=pre-pole-o ./scripts/backup-neo4j-only.sh      # appended to filename
+#   ./scripts/backup-neo4j-only.sh --dry-run           # check prereqs, no scale
+#   ./scripts/backup-neo4j-only.sh --verify <dump>     # load dump into scratch pod
+#
+# Exit codes:
+#   0  success (dump file written, non-empty, service restored)
+#   1  prerequisite failure (no kubectl, no deploy, no PVC, T7 missing)
+#   2  dump failed
+#   3  copy-out failed or empty dump
+#   4  service restore failed (CRITICAL — Neo4j may be down)
+
+set -uo pipefail
+
+# ── config ──
+NS="${NS:-asgard-infra}"
+DEPLOY="${DEPLOY:-neo4j}"
+HELPER_POD="${HELPER_POD:-neo4j-backup-helper-$$}"
+DB_NAME="${DB_NAME:-neo4j}"
+DATE=$(date +%Y-%m-%d)
+TS=$(date +%Y-%m-%d_%H%M%S)
+TAG="${TAG:-}"
+DEST_DEFAULT="/Volumes/T7 Shield/asgard-neo4j-backup-${DATE}"
+DEST="${DEST:-$DEST_DEFAULT}"
+WAIT_SCALE_DOWN_S="${WAIT_SCALE_DOWN_S:-120}"
+WAIT_HELPER_READY_S="${WAIT_HELPER_READY_S:-120}"
+WAIT_SCALE_UP_S="${WAIT_SCALE_UP_S:-180}"
+DRY_RUN=0
+VERIFY_MODE=0
+VERIFY_FILE=""
+
+# ── logging ──
+LOG() { echo "$(date +%H:%M:%S) [neo4j-bk] $*"; }
+OK()  { echo "$(date +%H:%M:%S) [   ✅  ] $*"; }
+ERR() { echo "$(date +%H:%M:%S) [   ❌  ] $*" >&2; }
+WARN(){ echo "$(date +%H:%M:%S) [   ⚠️  ] $*" >&2; }
+
+# ── parse args ──
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --verify)  VERIFY_MODE=1; VERIFY_FILE="${2:-}"; shift 2 ;;
+    -h|--help)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) ERR "unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# ── prereq checks (exit 1 on any miss) ──
+command -v kubectl >/dev/null 2>&1 || { ERR "kubectl not in PATH"; exit 1; }
+
+if [ "$VERIFY_MODE" -eq 1 ]; then
+  [ -f "$VERIFY_FILE" ] || { ERR "--verify needs a dump file path"; exit 1; }
+fi
+
+ORIG_REPLICAS=""
+PVC=""
+IMAGE=""
+
+discover_deploy() {
+  IMAGE=$(kubectl get deploy "$DEPLOY" -n "$NS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  PVC=$(kubectl get deploy "$DEPLOY" -n "$NS" \
+        -o jsonpath='{.spec.template.spec.volumes[?(@.persistentVolumeClaim)].persistentVolumeClaim.claimName}' \
+        2>/dev/null | awk '{print $1}')
+  ORIG_REPLICAS=$(kubectl get deploy "$DEPLOY" -n "$NS" -o jsonpath='{.spec.replicas}' 2>/dev/null)
+
+  [ -z "$IMAGE" ] && { ERR "deploy/${DEPLOY} not found in ns/${NS}"; exit 1; }
+  PVC="${PVC:-neo4j-data}"
+  ORIG_REPLICAS="${ORIG_REPLICAS:-1}"
+  LOG "discovered: image=$IMAGE pvc=$PVC orig_replicas=$ORIG_REPLICAS"
+}
+
+# ── trap: ALWAYS try to restore service + cleanup helper ──
+cleanup() {
+  local rc=$?
+  LOG "cleanup (exit=${rc})"
+  kubectl delete pod "$HELPER_POD" -n "$NS" --wait=false >/dev/null 2>&1 || true
+  if [ -n "$ORIG_REPLICAS" ] && [ "$DRY_RUN" -eq 0 ] && [ "$VERIFY_MODE" -eq 0 ]; then
+    kubectl scale deploy/"$DEPLOY" -n "$NS" --replicas="$ORIG_REPLICAS" >/dev/null 2>&1
+    LOG "scaled deploy/${DEPLOY} back to ${ORIG_REPLICAS}"
+    local back_up=0
+    for i in $(seq 1 $((WAIT_SCALE_UP_S / 5))); do
+      if kubectl get pods -n "$NS" --no-headers 2>/dev/null | grep "^${DEPLOY}-" | grep -q "1/1.*Running"; then
+        OK "neo4j back online"
+        back_up=1
+        break
+      fi
+      sleep 5
+    done
+    if [ "$back_up" -eq 0 ]; then
+      ERR "neo4j did NOT come back online within ${WAIT_SCALE_UP_S}s — CHECK MANUALLY"
+      exit 4
+    fi
+  fi
+}
+trap cleanup EXIT
+
+# ════════════ MODES ════════════
+
+verify_dump() {
+  LOG "=== Verify dump: ${VERIFY_FILE} ==="
+  discover_deploy
+  [ -s "$VERIFY_FILE" ] || { ERR "dump file empty"; exit 3; }
+  local sz; sz=$(du -h "$VERIFY_FILE" | cut -f1)
+  LOG "dump size: $sz"
+
+  # Spin scratch pod with empty volume, load dump, print summary. No impact on prod Neo4j.
+  local scratch="neo4j-verify-$$"
+  LOG "launching scratch pod ${scratch} (read-only verify, no PVC mount)"
+  kubectl apply -f - >/dev/null 2>&1 <<YAML
+apiVersion: v1
+kind: Pod
+metadata: {name: ${scratch}, namespace: ${NS}}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: verify
+    image: ${IMAGE}
+    command: ["sleep","600"]
+    volumeMounts:
+    - {name: scratch, mountPath: /data}
+  volumes:
+  - {name: scratch, emptyDir: {}}
+YAML
+  kubectl wait --for=condition=Ready pod/"$scratch" -n "$NS" --timeout=120s >/dev/null 2>&1 \
+    || { ERR "scratch pod not ready"; kubectl delete pod "$scratch" -n "$NS" --wait=false >/dev/null 2>&1; exit 3; }
+
+  kubectl cp "$VERIFY_FILE" "${NS}/${scratch}:/tmp/${DB_NAME}.dump" 2>/dev/null \
+    || { ERR "cp dump to scratch failed"; kubectl delete pod "$scratch" -n "$NS" --wait=false >/dev/null 2>&1; exit 3; }
+
+  if kubectl exec -n "$NS" "$scratch" -- neo4j-admin database load "$DB_NAME" --from-path=/tmp --overwrite-destination 2>&1 | tail -5; then
+    OK "dump loads cleanly (load-test passed)"
+    kubectl delete pod "$scratch" -n "$NS" --wait=false >/dev/null 2>&1
+    exit 0
+  else
+    ERR "dump FAILED to load — backup is corrupt"
+    kubectl delete pod "$scratch" -n "$NS" --wait=false >/dev/null 2>&1
+    exit 3
+  fi
+}
+
+dry_run() {
+  LOG "=== DRY RUN — no scale, no dump ==="
+  discover_deploy
+  case "$DEST" in
+    /Volumes/T7*)
+      if [ ! -d "$(dirname "$DEST")" ]; then
+        ERR "T7 not mounted — $(dirname "$DEST") missing"
+        exit 1
+      fi
+      ;;
+  esac
+  mkdir -p "$DEST" 2>/dev/null || { ERR "cannot create DEST=$DEST"; exit 1; }
+  touch "$DEST/.write-test" && rm "$DEST/.write-test" || { ERR "DEST not writable"; exit 1; }
+  OK "prereqs OK — ready to run without --dry-run"
+  ORIG_REPLICAS=""   # disable trap restore
+  exit 0
+}
+
+[ "$VERIFY_MODE" -eq 1 ] && verify_dump
+[ "$DRY_RUN" -eq 1 ] && dry_run
+
+# ════════════ MAIN BACKUP ════════════
+
+LOG "=== Asgard Neo4j-only backup ${TS} ==="
+LOG "destination: ${DEST}"
+
+case "$DEST" in
+  /Volumes/T7*)
+    [ -d "$(dirname "$DEST")" ] || { ERR "T7 not mounted"; exit 1; }
+    ;;
+esac
+mkdir -p "$DEST" || { ERR "cannot create DEST=$DEST"; exit 1; }
+
+OUT_BASENAME="${DB_NAME}${TAG:+-${TAG}}.dump"
+OUT="${DEST}/${OUT_BASENAME}"
+
+discover_deploy
+
+# 1. scale down
+LOG "scaling deploy/${DEPLOY} → 0"
+kubectl scale deploy/"$DEPLOY" -n "$NS" --replicas=0 >/dev/null 2>&1
+local_done=0
+for i in $(seq 1 $((WAIT_SCALE_DOWN_S / 5))); do
+  kubectl get pods -n "$NS" --no-headers 2>/dev/null | grep -q "^${DEPLOY}-" || { local_done=1; break; }
+  sleep 5
+done
+[ "$local_done" -eq 1 ] || { ERR "neo4j pods did not terminate within ${WAIT_SCALE_DOWN_S}s"; exit 2; }
+OK "deploy scaled to 0"
+
+# 2. helper pod
+LOG "launching helper pod ${HELPER_POD}"
+kubectl apply -f - >/dev/null 2>&1 <<YAML
+apiVersion: v1
+kind: Pod
+metadata: {name: ${HELPER_POD}, namespace: ${NS}, labels: {role: backup-helper}}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: dump
+    image: ${IMAGE}
+    command: ["sleep","900"]
+    volumeMounts:
+    - {name: data, mountPath: /data}
+  volumes:
+  - {name: data, persistentVolumeClaim: {claimName: ${PVC}}}
+YAML
+
+kubectl wait --for=condition=Ready pod/"$HELPER_POD" -n "$NS" --timeout="${WAIT_HELPER_READY_S}s" >/dev/null 2>&1 \
+  || { ERR "helper pod not ready within ${WAIT_HELPER_READY_S}s"; exit 2; }
+OK "helper pod ready"
+
+# 3. dump
+LOG "running neo4j-admin database dump ${DB_NAME}"
+if kubectl exec -n "$NS" "$HELPER_POD" -- \
+     neo4j-admin database dump "$DB_NAME" --to-path=/tmp --overwrite-destination >/dev/null 2>&1; then
+  OK "dump created in helper:/tmp/${DB_NAME}.dump"
+else
+  ERR "neo4j-admin dump failed"
+  exit 2
+fi
+
+# 4. copy out
+LOG "copying dump → ${OUT}"
+if kubectl exec -n "$NS" "$HELPER_POD" -- cat "/tmp/${DB_NAME}.dump" > "$OUT" 2>/dev/null && [ -s "$OUT" ]; then
+  SIZE=$(du -h "$OUT" | cut -f1)
+  OK "dump → ${OUT_BASENAME} (${SIZE})"
+else
+  ERR "copy-out failed or empty"
+  exit 3
+fi
+
+# 5. manifest
+cat > "${DEST}/MANIFEST-${OUT_BASENAME}.md" <<EOF
+# Neo4j-only backup — ${TS}
+
+- File: \`${OUT_BASENAME}\`
+- Size: ${SIZE}
+- Source: ns/${NS} deploy/${DEPLOY} pvc/${PVC}
+- Image: ${IMAGE}
+- DB: ${DB_NAME}
+- Host: $(hostname)
+- Tag: ${TAG:-(none)}
+- Downtime: from $(date) — scale-back follows in cleanup trap
+
+## Restore
+\`\`\`
+# 1. stop neo4j
+kubectl scale deploy/neo4j -n ${NS} --replicas=0
+
+# 2. launch helper pod mounting neo4j-data PVC (same image: ${IMAGE})
+# 3. kubectl cp ${OUT_BASENAME} <ns>/<helper>:/tmp/${DB_NAME}.dump
+# 4. kubectl exec ... neo4j-admin database load ${DB_NAME} --from-path=/tmp --overwrite-destination
+# 5. delete helper, scale neo4j back to 1
+\`\`\`
+
+## Verify this dump
+\`\`\`
+./scripts/backup-neo4j-only.sh --verify ${OUT}
+\`\`\`
+EOF
+OK "manifest → MANIFEST-${OUT_BASENAME}.md"
+
+LOG "=== complete ==="
+# trap cleanup runs now: deletes helper, scales back to ORIG_REPLICAS

--- a/scripts/log_archiver.sh
+++ b/scripts/log_archiver.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 ARCHIVE_DIR="${ASGARD_ARCHIVE_DIR:-/Volumes/T7 Shield/Asgard-Archives/Heimdall-Logs}"
-LOG_DIR="${HEIMDALL_LOG_DIR:?Set HEIMDALL_LOG_DIR to the absolute path of Heimdall's logs/ directory}"
+LOG_DIR="${HEIMDALL_LOG_DIR:?Set HEIMDALL_LOG_DIR to the absolute path of the Heimdall logs/ directory}"
 
 # Ensure the archive directory exists
 mkdir -p "$ARCHIVE_DIR"

--- a/scripts/nightly-backup.sh
+++ b/scripts/nightly-backup.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  🏰 ASGARD — Nightly Backup Wrapper                          ║
+# ╚══════════════════════════════════════════════════════════════╝
+# Wraps backup-full-k8s.sh for scheduled (launchd) execution:
+#   guard (T7 mounted) → disk headroom check → backup → rotate → heartbeat → notify
+#
+# Scheduled via launchd `com.asgard.nightly-backup` (03:00 daily).
+# Retention (tiered): keep last KEEP_DAILY days + Sunday weeklies up to
+# KEEP_WEEKLY_DAYS old. Steady state ≈ 10 dirs (~40 GB) instead of 30 (~120 GB).
+#
+# Manual run / dry test:  ./scripts/nightly-backup.sh
+set -uo pipefail
+
+T7="/Volumes/T7 Shield"
+SCRIPT_DIR="/Users/mimir/Developer/Asgard/scripts"
+LOG_DIR="/Users/mimir/Developer/Asgard/logs"
+HEARTBEAT="${T7}/asgard-backups/last-backup-status.txt"
+KEEP_DAILY=7        # every backup from the last N days
+KEEP_WEEKLY_DAYS=35 # Sunday backups kept this many days back
+TS=$(date +%Y-%m-%d_%H%M%S)
+
+mkdir -p "$LOG_DIR"
+LOG="${LOG_DIR}/nightly-backup.log"
+log()    { echo "$(date '+%F %T') $*" | tee -a "$LOG"; }
+notify() { /usr/bin/osascript -e "display notification \"$1\" with title \"Asgard Backup\"" 2>/dev/null || true; }
+# Discord embed ($1=color $2=title $3=desc) — reuses the watchdog webhook config.
+discord_notify() {
+  [ -f "$HOME/.asgard-watchdog.env" ] && . "$HOME/.asgard-watchdog.env" 2>/dev/null
+  [ -z "${DISCORD_WEBHOOK:-}" ] && return 0
+  local payload
+  payload=$(DN_C="$1" DN_T="$2" DN_D="$3" DN_TS="$TS" python3 -c 'import json,os;print(json.dumps({"embeds":[{"title":os.environ["DN_T"],"description":os.environ["DN_D"],"color":int(os.environ["DN_C"]),"footer":{"text":"asgard nightly-backup • "+os.environ["DN_TS"]}}]}))' 2>/dev/null)
+  [ -n "$payload" ] && curl -s --max-time 12 -H 'Content-Type: application/json' -d "$payload" "$DISCORD_WEBHOOK" >/dev/null 2>&1
+}
+
+log "════════ nightly backup start (${TS}) ════════"
+
+# 1. Guard — T7 mounted AND writable (don't run a half-backup onto the boot disk)
+if [ ! -d "$T7" ] || ! touch "${T7}/.write-test" 2>/dev/null; then
+  log "FAIL: T7 not mounted/writable — skipping run"
+  notify "T7 not mounted — nightly backup skipped"
+  discord_notify 15105570 "🟠 Asgard Backup SKIPPED" "T7 ไม่ได้ mount/เขียนไม่ได้ — nightly backup ข้ามรอบนี้ (เสียบ T7 แล้วรันมือ: nightly-backup.sh)"
+  mkdir -p "$(dirname "$HEARTBEAT")" 2>/dev/null || true
+  printf "last_run=%s\nstatus=SKIPPED_NO_T7\n" "$TS" > "$HEARTBEAT" 2>/dev/null || true
+  exit 1
+fi
+rm -f "${T7}/.write-test"
+
+# 2. Host disk headroom (the real constraint — warn under 20 GB)
+FREE_GB=$(df -g /System/Volumes/Data 2>/dev/null | awk 'NR==2{print $4}')
+log "host disk free: ${FREE_GB:-?} GB"
+if [ "${FREE_GB:-0}" -lt 20 ]; then
+  log "WARN: host disk < 20 GB free before backup"
+  notify "host disk low (${FREE_GB}GB) — backup proceeding"
+fi
+
+# 3. Run the full backup (writes to T7/asgard-backup-<DATE>/)
+"${SCRIPT_DIR}/backup-full-k8s.sh" >>"$LOG" 2>&1
+RC=$?
+log "backup-full-k8s.sh exit=${RC}"
+
+# 4. Rotate — tiered: keep last KEEP_DAILY days, plus Sundays ≤ KEEP_WEEKLY_DAYS old
+NOW_EPOCH=$(date +%s)
+for d in "${T7}"/asgard-backup-*; do
+  [ -d "$d" ] || continue
+  dt="${d##*/asgard-backup-}"
+  dt_epoch=$(date -j -f "%Y-%m-%d" "$dt" +%s 2>/dev/null) || continue  # skip non-dated dirs
+  age_days=$(( (NOW_EPOCH - dt_epoch) / 86400 ))
+  dow=$(date -j -f "%Y-%m-%d" "$dt" +%u 2>/dev/null)
+  [ "$age_days" -le "$KEEP_DAILY" ] && continue
+  [ "$dow" = "7" ] && [ "$age_days" -le "$KEEP_WEEKLY_DAYS" ] && continue
+  log "rotate: removing old backup ${d} (age=${age_days}d)"
+  rm -rf "$d"
+done
+
+# 5. Heartbeat — single glanceable status file on T7
+LATEST=$(ls -dt "${T7}"/asgard-backup-* 2>/dev/null | head -1)
+# NOTE: `grep -c` prints "0" but EXITS 1 when there are no FAIL rows (the normal,
+# healthy case). The old `|| echo "?"` then appended "?", making FAILS="0\n?" —
+# which is != "0" and != "?", so every successful backup falsely fired the
+# "🔴 ISSUES" alert (and leaked a stray "?"). Capture only grep's stdout; use "?"
+# solely when the manifest is missing/unreadable (empty result).
+FAILS=$(grep -c "| FAIL |" "${LATEST}/MANIFEST.md" 2>/dev/null || true)
+[ -n "$FAILS" ] || FAILS="?"
+SIZE=$(du -sh "$LATEST" 2>/dev/null | cut -f1)
+KEPT=$(ls -d "${T7}"/asgard-backup-* 2>/dev/null | wc -l | tr -d ' ')
+{
+  echo "last_run=${TS}"
+  echo "exit_code=${RC}"
+  echo "latest=${LATEST}"
+  echo "size=${SIZE}"
+  echo "failed_components=${FAILS}"
+  echo "retained_backups=${KEPT}"
+} > "$HEARTBEAT"
+log "heartbeat: size=${SIZE} fails=${FAILS} retained=${KEPT}"
+
+# 5b. Off-site mirror → GCS (optional, for disaster recovery — T7 is a single drive).
+# Config in ~/.asgard-watchdog.env:
+#   GCS_BACKUP_BUCKET=asgard-archive   (bucket name, no gs://)
+#   GCS_SA_KEY=/path/to/sa-key.json    (service account key — for UNATTENDED auth;
+#                                        user-login tokens expire and break 3AM runs)
+#   GCS_MIRROR_DOW=7                    (1=Mon..7=Sun to upload; "*"=every night; default 7)
+#   GCS_STORAGE_CLASS=COLDLINE  GCS_PROJECT=asgard-489513
+GCS_STATUS="off (GCS_BACKUP_BUCKET not set)"
+[ -f "$HOME/.asgard-watchdog.env" ] && . "$HOME/.asgard-watchdog.env" 2>/dev/null
+if [ -n "${GCS_BACKUP_BUCKET:-}" ] && [ -n "${LATEST:-}" ]; then
+  DOW=$(date +%u); WANT="${GCS_MIRROR_DOW:-7}"
+  if [ "$WANT" = "*" ] || [ "$DOW" = "$WANT" ]; then
+    [ -n "${GCS_SA_KEY:-}" ] && [ -f "${GCS_SA_KEY}" ] && \
+      gcloud auth activate-service-account --key-file="${GCS_SA_KEY}" --project="${GCS_PROJECT:-asgard-489513}" >>"$LOG" 2>&1
+    DEST_URI="gs://${GCS_BACKUP_BUCKET}/infra-backups/$(basename "$LATEST")"
+    log "GCS mirror → ${DEST_URI}"
+    if gcloud storage cp -r "$LATEST" "gs://${GCS_BACKUP_BUCKET}/infra-backups/" \
+         --storage-class="${GCS_STORAGE_CLASS:-COLDLINE}" >>"$LOG" 2>&1; then
+      GCS_STATUS="OK → ${DEST_URI}"; log "GCS mirror OK"
+    else
+      GCS_STATUS="FAILED (check gcloud auth / SA key)"; log "GCS mirror FAILED"
+    fi
+  else
+    GCS_STATUS="skipped (weekly: uploads on DOW=${WANT}, today=${DOW})"
+  fi
+fi
+log "gcs: ${GCS_STATUS}"
+
+# 6. Notify on any problem (non-zero exit OR a FAIL row in the manifest)
+if [ "$RC" -ne 0 ] || { [ "$FAILS" != "0" ] && [ "$FAILS" != "?" ]; }; then
+  notify "needs attention: ${FAILS} failed component(s), rc=${RC}"
+  discord_notify 15158332 "🔴 Asgard Backup ISSUES" "fails=${FAILS} • rc=${RC} • size=${SIZE} • gcs: ${GCS_STATUS}"
+  log "════════ FINISHED WITH ISSUES (fails=${FAILS}, rc=${RC}) ════════"
+  exit 2
+fi
+discord_notify 3066993 "🟢 Asgard Backup OK" "size=${SIZE} • retained=${KEPT} backups • gcs: ${GCS_STATUS}"
+log "════════ nightly backup OK (${SIZE}) ════════"

--- a/scripts/restore-from-backup.sh
+++ b/scripts/restore-from-backup.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  🏰 ASGARD — Restore from backup (drill / DR)                  ║
+# ║  V1: MariaDB + Neo4j only (the schema layers Sprint 56 mutates)║
+# ║  Defaults to a scratch namespace — explicit flag for prod      ║
+# ╚══════════════════════════════════════════════════════════════╝
+#
+# Companion to backup-full-k8s.sh + backup-neo4j-only.sh.
+#
+# Required by ADR-011 §D6 as the Sprint 56 exit criterion: a successful
+# restore drill must be demonstrated in a scratch namespace before the
+# sprint can close.
+#
+# V1 scope (intentional):
+#   - MariaDB logical restore (.sql.gz → mysql import)
+#   - Neo4j binary restore (.dump → neo4j-admin database load)
+#   - Postgres logical restore (.sql.gz → psql import)
+#   - Counts/integrity check after each
+#
+# Out of scope (use the source backup files + per-service docs):
+#   - Qdrant snapshot recovery (API-driven, per collection)
+#   - ClickHouse raw tar extract
+#   - Vault raft snapshot restore
+#   - PV raw tar restore
+#
+# Safety:
+#   - Default --target-ns is a SCRATCH namespace, never prod
+#   - --target-ns prod-asgard-infra requires explicit --i-know-this-is-prod
+#   - Each component restore is independent; failure is logged, others continue
+#   - trap on EXIT ensures helper pods + port-forwards are cleaned up
+#
+# Usage:
+#   ./scripts/restore-from-backup.sh /Volumes/T7\ Shield/asgard-backup-2026-05-23
+#     → restores into ns asgard-restore-drill (default scratch)
+#
+#   ./scripts/restore-from-backup.sh <backup-dir> --component neo4j
+#     → only Neo4j
+#
+#   ./scripts/restore-from-backup.sh <backup-dir> --target-ns my-test
+#     → custom scratch namespace
+#
+#   ./scripts/restore-from-backup.sh <backup-dir> --target-ns asgard \
+#       --i-know-this-is-prod
+#     → DESTRUCTIVE — overwrites prod data
+#
+# Exit codes:
+#   0  all requested components restored + counts verified
+#   1  prerequisite failure (no backup dir, no kubectl, ...)
+#   2  one or more component restores failed (see summary)
+#   3  prod target requested without explicit confirm flag
+
+set -uo pipefail
+
+# ── config ──
+BACKUP_DIR=""
+TARGET_NS="${TARGET_NS:-asgard-restore-drill}"
+COMPONENT="${COMPONENT:-all}"
+PROD_CONFIRM=0
+DRY_RUN=0
+HELPER_POD_PREFIX="restore-helper-$$"
+
+declare -a RESULTS=()
+record() { RESULTS+=("$1|$2|$3"); }
+
+LOG() { echo "$(date +%H:%M:%S) [restore] $*"; }
+OK()  { echo "$(date +%H:%M:%S) [   ✅  ] $*"; }
+ERR() { echo "$(date +%H:%M:%S) [   ❌  ] $*" >&2; }
+SKIP(){ echo "$(date +%H:%M:%S) [   ⏭️  ] $*"; }
+
+# ── parse args ──
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target-ns)            TARGET_NS="$2"; shift 2 ;;
+    --component)            COMPONENT="$2"; shift 2 ;;
+    --i-know-this-is-prod)  PROD_CONFIRM=1; shift ;;
+    --dry-run)              DRY_RUN=1; shift ;;
+    -h|--help)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    -*)
+      ERR "unknown flag: $1"; exit 1 ;;
+    *)
+      [ -z "$BACKUP_DIR" ] && BACKUP_DIR="$1" || { ERR "extra positional: $1"; exit 1; }
+      shift ;;
+  esac
+done
+
+# ── prereq checks ──
+[ -z "$BACKUP_DIR" ] && { ERR "usage: $0 <backup-dir>"; exit 1; }
+[ ! -d "$BACKUP_DIR" ] && { ERR "backup dir not found: $BACKUP_DIR"; exit 1; }
+[ ! -f "$BACKUP_DIR/MANIFEST.md" ] && { ERR "missing MANIFEST.md — not a valid backup dir"; exit 1; }
+command -v kubectl >/dev/null 2>&1 || { ERR "kubectl not in PATH"; exit 1; }
+
+# Prod safety gate — common prod ns names trigger the check.
+case "$TARGET_NS" in
+  asgard|asgard-infra|asgard-monitoring|wazuh)
+    if [ "$PROD_CONFIRM" -ne 1 ]; then
+      ERR "target ns '${TARGET_NS}' looks like prod. Add --i-know-this-is-prod to override."
+      exit 3
+    fi
+    LOG "⚠️  RESTORING TO PROD NS: ${TARGET_NS} (explicit confirm given)"
+    ;;
+esac
+
+# Ensure scratch ns exists
+if ! kubectl get ns "$TARGET_NS" >/dev/null 2>&1; then
+  LOG "creating namespace ${TARGET_NS}"
+  kubectl create ns "$TARGET_NS" >/dev/null 2>&1 \
+    || { ERR "cannot create ns ${TARGET_NS}"; exit 1; }
+fi
+
+LOG "=== Asgard Restore ==="
+LOG "  source:    ${BACKUP_DIR}"
+LOG "  target:    ns/${TARGET_NS}"
+LOG "  component: ${COMPONENT}"
+[ "$DRY_RUN" -eq 1 ] && LOG "  ⏸️  DRY RUN — no writes"
+
+# ── cleanup trap ──
+cleanup() {
+  LOG "cleanup"
+  kubectl get pods -n "$TARGET_NS" -l "role=restore-helper" --no-headers 2>/dev/null \
+    | awk '{print $1}' \
+    | xargs -I{} kubectl delete pod -n "$TARGET_NS" {} --wait=false >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+# ════════════ COMPONENT: MariaDB ════════════
+restore_mariadb() {  # $1=sql.gz file $2=deploy name (must exist in TARGET_NS)
+  local f="$1" deploy="$2"
+  [ ! -f "$f" ] && { SKIP "MariaDB ${deploy} — ${f} missing"; record "mariadb-${deploy}" SKIP "no dump"; return; }
+
+  local pod
+  pod=$(kubectl get pods -n "$TARGET_NS" --no-headers 2>/dev/null \
+        | awk -v p="$deploy" '$1 ~ "^"p && $3=="Running" {print $1; exit}')
+  if [ -z "$pod" ]; then
+    SKIP "MariaDB ${deploy} — no running pod in ns/${TARGET_NS} (deploy the stack first)"
+    record "mariadb-${deploy}" SKIP "no pod"
+    return
+  fi
+
+  LOG "📊 MariaDB ${deploy} ← ${f}"
+  [ "$DRY_RUN" -eq 1 ] && { OK "  (dry-run, no import)"; record "mariadb-${deploy}" DRYRUN "${f}"; return; }
+
+  if gunzip -c "$f" | kubectl exec -i -n "$TARGET_NS" "$pod" -- sh -c \
+       'mariadb -uroot -p"${MYSQL_ROOT_PASSWORD:-${MARIADB_ROOT_PASSWORD:-root}}" 2>/dev/null'; then
+    # count check — sum rows across all user DBs
+    local cnt
+    cnt=$(kubectl exec -n "$TARGET_NS" "$pod" -- sh -c \
+          'mariadb -uroot -p"${MYSQL_ROOT_PASSWORD:-${MARIADB_ROOT_PASSWORD:-root}}" -BN \
+             -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema NOT IN (\"mysql\",\"information_schema\",\"performance_schema\",\"sys\")" 2>/dev/null')
+    OK "MariaDB ${deploy} → ${cnt:-?} user tables"
+    record "mariadb-${deploy}" OK "${cnt} tables"
+  else
+    ERR "MariaDB ${deploy} import failed"
+    record "mariadb-${deploy}" FAIL "import error"
+  fi
+}
+
+# ════════════ COMPONENT: Postgres ════════════
+restore_postgres() {  # $1=sql.gz file $2=deploy name
+  local f="$1" deploy="$2"
+  [ ! -f "$f" ] && { SKIP "Postgres ${deploy} — ${f} missing"; record "postgres-${deploy}" SKIP "no dump"; return; }
+
+  local pod
+  pod=$(kubectl get pods -n "$TARGET_NS" --no-headers 2>/dev/null \
+        | awk -v p="$deploy" '$1 ~ "^"p && $3=="Running" {print $1; exit}')
+  if [ -z "$pod" ]; then
+    SKIP "Postgres ${deploy} — no running pod in ns/${TARGET_NS}"
+    record "postgres-${deploy}" SKIP "no pod"
+    return
+  fi
+
+  LOG "🐘 Postgres ${deploy} ← ${f}"
+  [ "$DRY_RUN" -eq 1 ] && { OK "  (dry-run)"; record "postgres-${deploy}" DRYRUN "${f}"; return; }
+
+  if gunzip -c "$f" | kubectl exec -i -n "$TARGET_NS" "$pod" -- sh -c \
+       'PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD:-}}" psql -U "${POSTGRES_USER:-postgres}" 2>/dev/null'; then
+    local cnt
+    cnt=$(kubectl exec -n "$TARGET_NS" "$pod" -- sh -c \
+          'PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD:-}}" psql -U "${POSTGRES_USER:-postgres}" -tA \
+             -c "SELECT count(*) FROM information_schema.tables WHERE table_schema NOT IN (\"pg_catalog\",\"information_schema\")" 2>/dev/null')
+    OK "Postgres ${deploy} → ${cnt:-?} user tables"
+    record "postgres-${deploy}" OK "${cnt} tables"
+  else
+    ERR "Postgres ${deploy} import failed"
+    record "postgres-${deploy}" FAIL "import error"
+  fi
+}
+
+# ════════════ COMPONENT: Neo4j ════════════
+restore_neo4j() {  # $1=neo4j.dump file
+  local f="$1"
+  [ ! -f "$f" ] && { SKIP "Neo4j — ${f} missing"; record "neo4j" SKIP "no dump"; return; }
+
+  local deploy="neo4j"
+  local image pvc orig_replicas
+  image=$(kubectl get deploy "$deploy" -n "$TARGET_NS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  pvc=$(kubectl get deploy "$deploy" -n "$TARGET_NS" \
+        -o jsonpath='{.spec.template.spec.volumes[?(@.persistentVolumeClaim)].persistentVolumeClaim.claimName}' \
+        2>/dev/null | awk '{print $1}')
+  orig_replicas=$(kubectl get deploy "$deploy" -n "$TARGET_NS" -o jsonpath='{.spec.replicas}' 2>/dev/null)
+
+  if [ -z "$image" ]; then
+    SKIP "Neo4j — deploy not found in ns/${TARGET_NS} (deploy the stack first)"
+    record "neo4j" SKIP "no deploy"
+    return
+  fi
+  pvc="${pvc:-neo4j-data}"
+  orig_replicas="${orig_replicas:-1}"
+
+  LOG "🕸️  Neo4j ← ${f} (image=${image} pvc=${pvc})"
+  [ "$DRY_RUN" -eq 1 ] && { OK "  (dry-run)"; record "neo4j" DRYRUN "${f}"; return; }
+
+  # 1. scale to 0
+  LOG "  scale neo4j → 0"
+  kubectl scale deploy/"$deploy" -n "$TARGET_NS" --replicas=0 >/dev/null 2>&1
+  for i in $(seq 1 24); do
+    kubectl get pods -n "$TARGET_NS" --no-headers 2>/dev/null | grep -q "^${deploy}-" || break
+    sleep 5
+  done
+
+  # 2. helper pod with same PVC
+  local helper="${HELPER_POD_PREFIX}-neo4j"
+  kubectl apply -f - >/dev/null 2>&1 <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${helper}
+  namespace: ${TARGET_NS}
+  labels: {role: restore-helper}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: load
+    image: ${image}
+    command: ["sleep","900"]
+    volumeMounts:
+    - {name: data, mountPath: /data}
+  volumes:
+  - {name: data, persistentVolumeClaim: {claimName: ${pvc}}}
+YAML
+
+  if ! kubectl wait --for=condition=Ready pod/"$helper" -n "$TARGET_NS" --timeout=120s >/dev/null 2>&1; then
+    ERR "Neo4j helper pod not ready — restoring service scale"
+    kubectl scale deploy/"$deploy" -n "$TARGET_NS" --replicas="$orig_replicas" >/dev/null 2>&1
+    record "neo4j" FAIL "helper not ready"
+    return
+  fi
+
+  # 3. copy dump in + load
+  if kubectl cp "$f" "${TARGET_NS}/${helper}:/tmp/neo4j.dump" 2>/dev/null \
+     && kubectl exec -n "$TARGET_NS" "$helper" -- \
+          neo4j-admin database load neo4j --from-path=/tmp --overwrite-destination 2>&1 | tail -3 \
+     && OK "  load OK"; then
+    record "neo4j" OK "loaded"
+  else
+    ERR "Neo4j load failed"
+    record "neo4j" FAIL "load error"
+  fi
+
+  # 4. scale back + verify
+  kubectl delete pod "$helper" -n "$TARGET_NS" --wait=false >/dev/null 2>&1
+  kubectl scale deploy/"$deploy" -n "$TARGET_NS" --replicas="$orig_replicas" >/dev/null 2>&1
+  LOG "  waiting for neo4j to come back online"
+  for i in $(seq 1 36); do
+    if kubectl get pods -n "$TARGET_NS" --no-headers 2>/dev/null | grep "^${deploy}-" | grep -q "1/1.*Running"; then
+      OK "Neo4j back online"
+      break
+    fi
+    sleep 5
+  done
+}
+
+# ════════════ DISPATCH ════════════
+do_mariadb=0; do_postgres=0; do_neo4j=0
+case "$COMPONENT" in
+  all)      do_mariadb=1; do_postgres=1; do_neo4j=1 ;;
+  mariadb)  do_mariadb=1 ;;
+  postgres) do_postgres=1 ;;
+  neo4j)    do_neo4j=1 ;;
+  *) ERR "unknown component: ${COMPONENT} (all|mariadb|postgres|neo4j)"; exit 1 ;;
+esac
+
+# V1 restore: ONE source per service type — drill verifies the dump loads,
+# not multi-instance prod-DR (which requires multi-ns scratch deploy first).
+# Multi-source restore is deferred to V2.
+if [ "$do_mariadb" -eq 1 ]; then
+  restore_mariadb "${BACKUP_DIR}/01-databases/mariadb-asgard.sql.gz" "mariadb"
+fi
+if [ "$do_postgres" -eq 1 ]; then
+  restore_postgres "${BACKUP_DIR}/01-databases/postgres-asgard.sql.gz" "postgres"
+fi
+if [ "$do_neo4j" -eq 1 ]; then
+  restore_neo4j "${BACKUP_DIR}/01-databases/neo4j.dump"
+fi
+
+# ── summary ──
+echo
+LOG "=== Restore Summary ==="
+fails=0; oks=0; skips=0
+for r in "${RESULTS[@]}"; do
+  IFS='|' read -r n s d <<< "$r"
+  printf "  %-22s %-7s %s\n" "$n" "$s" "$d"
+  case "$s" in
+    FAIL)   fails=$((fails+1)) ;;
+    OK|DRYRUN) oks=$((oks+1)) ;;
+    SKIP)   skips=$((skips+1)) ;;
+  esac
+done
+echo
+
+if [ "$fails" -gt 0 ]; then
+  ERR "${fails} component(s) FAILED — see logs above"
+  exit 2
+fi
+if [ "$oks" -eq 0 ]; then
+  ERR "no components were actually restored (all skipped) — verify ns/${TARGET_NS} has the stack deployed first"
+  exit 2
+fi
+OK "${oks} component(s) restored, ${skips} skipped"
+exit 0

--- a/scripts/t7-unlock.sh
+++ b/scripts/t7-unlock.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  🏰 ASGARD — T7 Shield auto-unlock (APFS Encrypted)          ║
+# ╚══════════════════════════════════════════════════════════════╝
+# Unlocks + mounts the encrypted APFS volume "T7 Shield" at login.
+# Passphrase: ~/.asgard-t7-passphrase (0600; off-site copy in Secret Manager
+# `asgard-t7-passphrase`, project asgard-489513).
+# Scheduled via launchd `com.asgard.t7-unlock` (RunAtLoad). Dependent services
+# (eir-cgm-minio, vor-img) are KeepAlive=true and self-heal once mounted.
+set -uo pipefail
+
+PF="$HOME/.asgard-t7-passphrase"
+LOG="$HOME/Library/Logs/t7-unlock.log"
+log() { echo "$(date '+%F %T') $*" >> "$LOG"; }
+
+if [ -d "/Volumes/T7 Shield" ]; then
+  log "already mounted — nothing to do"
+  exit 0
+fi
+if [ ! -f "$PF" ]; then
+  log "FAIL: passphrase file missing ($PF)"
+  exit 1
+fi
+
+# Wait up to ~60s for the disk to enumerate after boot, then unlock by name.
+# apfs-list line: "APFS Volume Disk (Role):   disk4s1 (No specific role)" → id is $5.
+for i in $(seq 1 12); do
+  VOLID=$(diskutil apfs list 2>/dev/null | awk '/APFS Volume Disk/{id=$5} /Name:.*T7 Shield/{print id; exit}')
+  if [ -n "${VOLID:-}" ]; then
+    if printf %s "$(cat "$PF")" | diskutil apfs unlockVolume "$VOLID" -stdinpassphrase >> "$LOG" 2>&1; then
+      log "unlocked + mounted ${VOLID}"
+      exit 0
+    fi
+    log "unlock attempt failed for ${VOLID} (try $i)"
+  fi
+  sleep 5
+done
+log "FAIL: T7 Shield volume not found/unlockable after wait"
+exit 1


### PR DESCRIPTION
## Why

Odin reported two wedged `oauth2-proxy` pods on 2026-08-21. Fixing them turned up
something worse underneath: **four launchd ops jobs on the Mac mini had been dead
for weeks, and nothing said a word.**

launchd runs these jobs straight out of the Asgard working tree
(`/Users/mimir/Developer/Asgard/scripts/*.sh`), but several of the scripts only
ever existed on unmerged branches. When the checkout moved to `feat/nott-box-edge`
on 2026-07-28 the files vanished from disk, launchd started returning
`EX_CONFIG (78)` and dropped the jobs into the penalty box:

| job | dead since | consequence |
|---|---|---|
| `com.asgard.nightly-backup` | 2026-07-28 | 24 days with no full backup; off-site GCS mirror 26 days stale |
| `com.asgard.ca-expiry-watch` | 2026-07-28 | nothing watching the private CA that terminates every cluster TLS cert |
| `com.asgard.boot-report` | 2026-07-28 | no boot report |
| `com.asgard.t7-unlock` | 2026-07-28 | exit 127 — backup drive would not auto-unlock after a reboot |
| `com.asgard.log-archiver` | 2026-04-16 | separate break, see below |

A job that never runs never reports a failure, and `asgard-preflight` only checked
what the jobs *produce* (backup age) — which is why the backup gap surfaced 24 days
late and the CA watch would not have surfaced until a certificate expired.

## What this PR does

**Restores the stranded scripts onto `main`** — `nightly-backup.sh`,
`backup-full-k8s.sh`, `backup-neo4j-only.sh`, `restore-from-backup.sh`,
`asgard-ca-expiry-check.sh`, `asgard-boot-report.sh`, `t7-unlock.sh`.

**Unbreaks `log_archiver.sh`.** `chore: prepare for public release` reworded the
LOG_DIR error to `Heimdall's logs/`; the apostrophe inside `${VAR:?...}` is a live
quote character, so bash refused to parse the file at all — exit 2 every night
since April.

**Stops the Neo4j step from swallowing its own errors.** It recorded
`neo4j | FAIL | copyout` and nothing else, because `apply`, `wait` and the dump all
redirected to `/dev/null`.

**Refuses to run two full backups at once.** That FAIL was a collision: a manual run
and the launchd run overlapped, and the second found `neo4j-backup-helper` already
owned by the first, which deleted it mid-flight. Both runs also scale the same
deployments to 0 and back underneath each other.

**Teaches `asgard-preflight` to check the jobs themselves** (the real fix). Every
`com.asgard.*` job must have all of its program paths present on disk — covering
both the bare-script and `/bin/bash <script>` forms — and a job that is not
currently running must not carry a failing last exit code. `78` and a missing
program are FAIL; other non-zero is WARN; a running job's last exit is history, not
a verdict. The watchdog now catches this class of failure within one 5-minute tick.

**Vendors `asgard-preflight.sh` and `asgard-watchdog.sh` into the repo.** They were
the only ops scripts under no version control at all — and the live preflight had
drifted: last touched 2026-06-24, so it never picked up the Nótt HB prod section
added on 2026-07-10. The Cloud Run HB engine and the Nótt chat tunnel had gone
unwatched for six weeks.

## Verification on the mini

- `nightly-backup` end-to-end under launchd: `exit 0`, 2.5G, `failed_components=0`, Neo4j dump 240M
- off-site mirror pushed: `gs://asgard-infra-backups/infra-backups/asgard-backup-2026-08-21` (2.5G)
- `askr-offsite-backup` and `log-archiver`: both `exit 0`, first success in 23 days and since April
- `asgard-ca-expiry-check.sh`: CA trusted, 3589 days of headroom
- launchd check proved against a deliberately broken job — preflight returns code 2 and names it, then goes green when removed
- `asgard-preflight.sh`: **12 ok, 0 warn, 0 fail** (8 ok / 1 warn before)

Scripts are byte-identical to the copies now running on the mini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
