### PR TITLE
fix(k8s): label the namespaces the NetworkPolicies select on

### DIFF
--- a/k8s/00-namespaces/namespaces.yaml
+++ b/k8s/00-namespaces/namespaces.yaml
@@ -1,10 +1,28 @@
 # 🏰 Asgard — Kubernetes Namespaces
+#
+# The labels here are not decoration: k8s/04-security/network-policies.yaml
+# selects namespaces by `app.kubernetes.io/part-of: asgard` (infra DB access,
+# monitoring scrape) and asgard-rl's own policy selects by `name: <namespace>`.
+# A namespace missing one of these labels is silently denied by every policy
+# that selects on it — which is exactly what took SSO, Bifrost and mimir-api
+# down on 2026-08-22, when an OrbStack restart re-evaluated the policies and
+# the `asgard` namespace (57 pods, never declared here) turned out to have no
+# part-of label at all.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: asgard
+  labels:
+    app.kubernetes.io/part-of: asgard
+    name: asgard
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: asgard-infra
   labels:
     app.kubernetes.io/part-of: asgard
+    name: asgard-infra
     tier: infrastructure
 ---
 apiVersion: v1
@@ -13,6 +31,7 @@ metadata:
   name: asgard-services
   labels:
     app.kubernetes.io/part-of: asgard
+    name: asgard-services
     tier: services
 ---
 apiVersion: v1
@@ -21,4 +40,13 @@ metadata:
   name: asgard-monitoring
   labels:
     app.kubernetes.io/part-of: asgard
+    name: asgard-monitoring
     tier: monitoring
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: asgard-rl
+  labels:
+    app.kubernetes.io/part-of: asgard
+    name: asgard-rl

--- a/scripts/asgard-preflight.sh
+++ b/scripts/asgard-preflight.sh
@@ -29,7 +29,7 @@ JSON=0
 # Tunables
 MIN_FREE_GB="${MIN_FREE_GB:-8}"
 BACKUP_MAX_AGE_DAYS="${BACKUP_MAX_AGE_DAYS:-3}"
-KUBE_NS="${KUBE_NS:-asgard asgard-infra wazuh}"
+KUBE_NS="${KUBE_NS:-asgard asgard-infra asgard-rl wazuh}"
 KCTL="kubectl --request-timeout=8s"
 T7_BASE="${T7_BASE:-/Volumes/T7 Shield}"   # quoted everywhere (path has a space)
 
@@ -182,6 +182,61 @@ while read -r LABEL; do
   esac
 done < <(launchctl list 2>/dev/null | grep -oE 'com\.asgard\.[a-z0-9.-]+' | sort -u)
 (( LD_BAD == 0 )) && ok "launchd asgard jobs healthy"
+
+# ── 7. NetworkPolicy selectors that match nothing ─────────────────────────
+# 2026-08-22: an OrbStack restart re-evaluated every NetworkPolicy, and three
+# namespaces turned out to be missing the labels those policies select on — so
+# rules written to ALLOW database traffic could only deny it. Zitadel lost
+# Postgres, SSO died with it, and Bifrost/mimir-api followed. A namespaceSelector
+# that matches no namespace is never a working allow-rule; it is an outage
+# waiting for the next restart.
+section "🔒 NetworkPolicy selectors"
+NS_JSON="$($KCTL get ns -o json 2>/dev/null)"
+# A dormant namespace (no pods) with a broken selector is a warning; the same
+# break in a namespace that is actually serving is an outage in waiting.
+NS_WITH_PODS="$($KCTL get pods -A --no-headers 2>/dev/null | awk '{print $1}' | sort -u | tr '\n' ' ')"
+# NSJSON has to sit on the python3 command: in a pipeline the env prefix only
+# reaches the FIRST command, so hanging it off kubectl leaves python blind and
+# every selector then "matches no namespace".
+NP_ORPHANS=$($KCTL get netpol -A -o json 2>/dev/null | NSJSON="$NS_JSON" PODNS="$NS_WITH_PODS" python3 -c '
+import json, os, sys
+pols = json.load(sys.stdin).get("items", [])
+nss = json.loads(os.environ.get("NSJSON") or "{}").get("items", [])
+labels = [n["metadata"].get("labels") or {} for n in nss]
+live = set((os.environ.get("PODNS") or "").split())
+out = []
+for pol in pols:
+    meta = pol["metadata"]
+    ns_name = meta["namespace"]
+    pol_name = meta["name"]
+    for direction, key in (("ingress", "from"), ("egress", "to")):
+        for rule in pol.get("spec", {}).get(direction) or []:
+            for peer in rule.get(key) or []:
+                sel = (peer.get("namespaceSelector") or {}).get("matchLabels")
+                if not sel:
+                    continue
+                if not any(all(l.get(k) == v for k, v in sel.items()) for l in labels):
+                    pairs = ",".join(k + "=" + v for k, v in sorted(sel.items()))
+                    sev = "FAIL" if ns_name in live else "WARN"
+                    out.append(sev + "|" + ns_name + "/" + pol_name + " " + direction + " selects [" + pairs + "] - matches NO namespace")
+print("\n".join(sorted(set(out))))
+')
+NP_RC=$?
+if (( NP_RC != 0 )); then
+  # A check that cannot run must not read as a pass — that is how the label gap
+  # stayed invisible in the first place.
+  warn "netpol selector check failed to run (rc=${NP_RC})"
+elif [[ -n "$NP_ORPHANS" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    case "$line" in
+      FAIL\|*) fail "netpol ${line#FAIL|}" ;;
+      *)       warn "netpol ${line#WARN|} (namespace has no pods — latent)" ;;
+    esac
+  done <<< "$NP_ORPHANS"
+else
+  ok "every NetworkPolicy namespaceSelector matches a live namespace"
+fi
 
 # ── verdict ───────────────────────────────────────────────────────────────
 CODE=0; (( ${#WARNS[@]} > 0 )) && CODE=1; (( ${#FAILS[@]} > 0 )) && CODE=2


### PR DESCRIPTION
## The outage

08:14 this morning OrbStack restarted itself (the app bundle was replaced by an auto-update at
20:34 the night before; the VM logged a clean stop/start at 08:14:28). Every pod sandbox was
recreated and every NetworkPolicy was programmed from scratch — and that is when three namespaces
turned out to be missing the labels those policies select on:

| namespace | missing | consequence |
|---|---|---|
| `asgard` (57 pods) | `app.kubernetes.io/part-of=asgard` | denied from every infra database |
| `asgard-rl` | `part-of`, `name` | bifrost `PoolTimedOut` against mariadb |
| `asgard-infra` | `name=asgard-infra` | asgard-rl's own egress rule matched nothing |

`infra-allow-services` allows ingress to Postgres/MariaDB/Redis/Qdrant/Neo4j **only** from
namespaces labelled `part-of=asgard`. With the label absent, a rule written to allow could only
deny. Zitadel could not reach Postgres and crashlooped; both oauth2-proxies died behind it, so SSO
went down; bifrost and mimir-api failed their DB connections; asgard-rl's bifrost sat in
`PoolTimedOut`. Odin reported three wedged pods and the cause looked like the pods themselves.

Restored by labelling the namespaces; everything recovered without any image or config change.

## Why the manifest did not prevent it

`k8s/00-namespaces/namespaces.yaml` declared `asgard-infra`, `asgard-services` and
`asgard-monitoring` — but **not `asgard`**, the namespace where all 57 workloads actually run. It
was never declared, so it never carried the label the policies depend on, and nothing noticed for
149 days because the rules were only re-evaluated on a restart.

This PR declares all five namespaces with the labels both policy families select on
(`app.kubernetes.io/part-of` and the `name:` convention that `asgard-rl`'s policy uses), and says
in the file why they are load-bearing rather than decorative.

## The guard

A `namespaceSelector` that matches no namespace is never a working allow-rule — it is an outage
waiting for the next restart. preflight now checks every policy in the cluster:

- **FAIL** when the policy's namespace has running pods
- **WARN** when the namespace is dormant
- **WARN**, never a silent OK, when the check itself cannot run — silent-pass is how the original
  gap survived (the first two drafts of this check failed exactly that way and reported green)

Verified in both directions against a deliberately broken policy (`code 2` naming the policy;
clean after removal). It also found a real latent one already in the cluster:
`prudential-poc/poc-network-policy` selects `name=ingress-nginx`, a label that namespace does not
carry — dormant today because the namespace has no pods, but it would deny the POC's ingress the
moment it is redeployed. Labelling `ingress-nginx` and `prudential-poc` is left out of this PR
deliberately; that namespace belongs to a customer POC and the call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
